### PR TITLE
Update testing paths and fix imports in tests.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment_test.ts
+++ b/step-release-vis/src/app/components/environment/environment_test.ts
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EnvironmentComponent } from './environment';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('EnvironmentComponent', () => {
   let component: EnvironmentComponent;
@@ -8,7 +10,8 @@ describe('EnvironmentComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ EnvironmentComponent ]
+      declarations: [EnvironmentComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule]
     })
     .compileComponents();
   }));

--- a/step-release-vis/src/app/services/environment_test.ts
+++ b/step-release-vis/src/app/services/environment_test.ts
@@ -1,12 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
 import { EnvironmentService } from './environment';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('EnvironmentService', () => {
   let service: EnvironmentService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(EnvironmentService);
   });
 

--- a/step-release-vis/src/test.ts
+++ b/step-release-vis/src/test.ts
@@ -21,6 +21,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context('./', true, /\.spec\.ts$|_test\.ts$/);
 // And load the modules.
 context.keys().map(context);

--- a/step-release-vis/tsconfig.spec.json
+++ b/step-release-vis/tsconfig.spec.json
@@ -14,6 +14,7 @@
   ],
   "include": [
     "src/**/*.spec.ts",
+    "src/**/*_test.ts",
     "src/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
* Fix tests being ignored

_Angular's testing framework uses path names in order to find test files. By default it searches for `*.spec.ts` files. With our `_test.ts` convention the tests weren't executed._