### PR TITLE
Add route parameters to environment component.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -2,6 +2,8 @@ import {Component, OnInit} from '@angular/core';
 import {EnvironmentService} from '../../services/environment';
 import {Polygon} from '../../models/Polygon';
 import {random} from 'lodash';
+import {ActivatedRoute} from '@angular/router';
+import {ParamService} from '../../services/param';
 
 @Component({
   selector: 'app-environment',
@@ -14,17 +16,31 @@ export class EnvironmentComponent implements OnInit {
   height: number;
   polygons: Polygon[];
   envName: string;
-  // TODO(andreystar): add a parameter for json file
-  jsonFile = 'env.json';
+  // Currently the json file describes only one environment,
+  // therefore the file is directly associated with EnvironmentComponent.
+  // Later a parent component for multiple EnvironmentComponents will be introduced.
+  // Until then the constant parameters are specified in the url as query parameters.
+  // TODO(andreystar): Add parent component
+  jsonFile: string;
 
-  constructor(private environmentService: EnvironmentService) {
-    this.width = window.innerWidth;
-    this.height = window.innerHeight;
+  constructor(private route: ActivatedRoute,
+              private environmentService: EnvironmentService,
+              private paramService: ParamService) {
   }
 
   ngOnInit(): void {
-    this.environmentService.getPolygons(this.jsonFile)
-      .subscribe(polygons => this.processPolygons(polygons));
+    // TODO(andreystar): make width and height configurable (requires parent component)
+    this.width = window.innerWidth;
+    this.height = window.innerHeight / 5;
+
+    this.paramService.param(this.route, 'jsonFile', '')
+      .subscribe(jsonFile => {
+        this.jsonFile = jsonFile;
+        this.environmentService.getPolygons(this.jsonFile)
+          .subscribe(polygons => this.processPolygons(polygons));
+      });
+    this.paramService.param(this.route, 'envName', 'prod')
+      .subscribe(envName => this.envName = envName);
   }
 
   // TODO(andreystar): add polygon processing logic

--- a/step-release-vis/src/app/components/environment/environment_test.ts
+++ b/step-release-vis/src/app/components/environment/environment_test.ts
@@ -3,33 +3,29 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {EnvironmentComponent} from './environment';
 import {RouterTestingModule} from '@angular/router/testing';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
-import {Observable, of} from 'rxjs';
-import {Polygon} from '../../models/Polygon';
 import {EnvironmentService} from '../../services/environment';
+import {EnvironmentServiceStub} from '../../../testing/EnvironmentServiceStub';
+import {ActivatedRoute} from '@angular/router';
+import {ActivatedRouteStub} from '../../../testing/ActivatedRouteStub';
 
 describe('EnvironmentComponent', () => {
   let component: EnvironmentComponent;
   let fixture: ComponentFixture<EnvironmentComponent>;
-  const fakeEnvironmentService = {
-    getPolygons(jsonFile: string): Observable<Polygon[]> {
-      return of([
-        new Polygon(
-          [
-            {x: 0, y: 0},
-            {x: 0, y: 1},
-            {x: 1, y: 1},
-            {x: 1, y: 0},
-          ],
-          'test'
-        )
-      ]);
-    }
+  let environmentServiceStub: EnvironmentServiceStub;
+  let activatedRouteStub: ActivatedRouteStub;
+  const routeParams = {
+    jsonFile: 'test.json',
+    envName: 'test'
   };
-
   beforeEach(async(() => {
+    environmentServiceStub = new EnvironmentServiceStub();
+    activatedRouteStub = new ActivatedRouteStub(routeParams);
     TestBed.configureTestingModule({
       declarations: [EnvironmentComponent],
-      providers: [{provide: EnvironmentService, useValue: fakeEnvironmentService}],
+      providers: [
+        {provide: EnvironmentService, useValue: environmentServiceStub},
+        {provide: ActivatedRoute, useValue: activatedRouteStub}
+      ],
       imports: [RouterTestingModule, HttpClientTestingModule]
     })
       .compileComponents();
@@ -45,9 +41,17 @@ describe('EnvironmentComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('query params should be assigned', () => {
+    fixture.detectChanges();
+    expect(component.jsonFile).toEqual(routeParams.jsonFile);
+    expect(component.envName).toEqual(routeParams.envName);
+  });
+
   it('colors should be assigned', () => {
     fixture.detectChanges();
-    component.polygons.forEach(({color}) =>
-      expect(color).toMatch(/^#[0-9a-f]{6}$/));
+    component.polygons.forEach(({color, candName}) => {
+      expect(color).toMatch(/^#[0-9a-f]{6}$/);
+      expect(candName).toEqual('test');
+    });
   });
 });

--- a/step-release-vis/src/app/components/grid/canvas/canvas_test.ts
+++ b/step-release-vis/src/app/components/grid/canvas/canvas_test.ts
@@ -9,7 +9,7 @@ describe('CanvasGridComponent', () => {
   let component: CanvasGridComponent;
   let fixture: ComponentFixture<CanvasGridComponent>;
   let activatedRouteStub: ActivatedRouteStub;
-  const params = {
+  const routeParams = {
     c: 1,
     w: 2,
     h: 3,
@@ -17,7 +17,7 @@ describe('CanvasGridComponent', () => {
   };
 
   beforeEach(async(() => {
-    activatedRouteStub = new ActivatedRouteStub(params);
+    activatedRouteStub = new ActivatedRouteStub(routeParams);
     TestBed.configureTestingModule({
       declarations: [ CanvasGridComponent ],
       providers: [
@@ -40,10 +40,10 @@ describe('CanvasGridComponent', () => {
 
   it('params should be assigned', () => {
     fixture.detectChanges();
-    expect(component.grids).toEqual(params.c);
-    expect(component.gridWidth).toEqual(params.w);
-    expect(component.gridHeight).toEqual(params.h);
-    expect(component.fps).toEqual(params.fps);
+    expect(component.grids).toEqual(routeParams.c);
+    expect(component.gridWidth).toEqual(routeParams.w);
+    expect(component.gridHeight).toEqual(routeParams.h);
+    expect(component.fps).toEqual(routeParams.fps);
   });
 
   it('canvas initialized', () => {

--- a/step-release-vis/src/app/components/grid/svg/svg_test.ts
+++ b/step-release-vis/src/app/components/grid/svg/svg_test.ts
@@ -9,7 +9,7 @@ describe('SvgGridComponent', () => {
   let component: SvgGridComponent;
   let fixture: ComponentFixture<SvgGridComponent>;
   let activatedRouteStub: ActivatedRouteStub;
-  const params = {
+  const routeParams = {
     c: 1,
     w: 2,
     h: 3,
@@ -17,7 +17,7 @@ describe('SvgGridComponent', () => {
   };
 
   beforeEach(async(() => {
-    activatedRouteStub = new ActivatedRouteStub(params);
+    activatedRouteStub = new ActivatedRouteStub(routeParams);
     TestBed.configureTestingModule({
       declarations: [ SvgGridComponent ],
       providers: [
@@ -40,10 +40,10 @@ describe('SvgGridComponent', () => {
 
   it('params should be assigned', () => {
     fixture.detectChanges();
-    expect(component.grids).toEqual(params.c);
-    expect(component.gridWidth).toEqual(params.w);
-    expect(component.gridHeight).toEqual(params.h);
-    expect(component.rectRadius).toEqual(params.r);
+    expect(component.grids).toEqual(routeParams.c);
+    expect(component.gridWidth).toEqual(routeParams.w);
+    expect(component.gridHeight).toEqual(routeParams.h);
+    expect(component.rectRadius).toEqual(routeParams.r);
   });
 
   it('svg initialized', () => {

--- a/step-release-vis/src/testing/EnvironmentServiceStub.ts
+++ b/step-release-vis/src/testing/EnvironmentServiceStub.ts
@@ -1,0 +1,26 @@
+import {Injectable} from '@angular/core';
+import {Observable, of} from 'rxjs';
+import {Polygon} from '../app/models/Polygon';
+import {EnvironmentService} from '../app/services/environment';
+
+@Injectable()
+export class EnvironmentServiceStub {
+
+  candName = 'test';
+
+  polygons = [
+    new Polygon(
+      [
+        {x: 0, y: 0},
+        {x: 0, y: 1},
+        {x: 1, y: 1},
+        {x: 1, y: 0},
+      ],
+      this.candName
+    )
+  ];
+
+  getPolygons(jsonFile: string): Observable<Polygon[]> {
+    return of(this.polygons);
+  }
+}


### PR DESCRIPTION
* Add json file and environment name parameters to route.

_Currently the json file describes only one environment, therefore the file is directly associated with EnvironmentComponent. Later a parent component for multiple EnvironmentComponents will be introduced. Until then the constant parameters are specified in the url as query parameters._