### PR TITLE
Update implementation to use lower bounds insted of upper bounds.

### DIFF
--- a/step-release-vis/src/app/services/environment.ts
+++ b/step-release-vis/src/app/services/environment.ts
@@ -59,30 +59,6 @@ export class EnvironmentService {
     return new Polygon(points, candidate);
   }
 
-  private closePolygons(
-    polys: Polygon[],
-    lower: Map<string, Point[]>,
-    upper: Map<string, Point[]>,
-    set: TimestampLowerBoundSet
-  ): TimestampLowerBoundSet {
-    const newSet: TimestampLowerBoundSet = new TimestampLowerBoundSet();
-
-    for (let i = 0; i < set.snapshot.length; i++) {
-      if (
-        set.snapshot[i].position ===
-        (i === set.snapshot.length - 1 ? 100 : set.snapshot[i + 1].position)
-      ) {
-        const name: string = set.snapshot[i].candName;
-        polys.push(this.createPolygon(lower.get(name), upper.get(name), name));
-      } else {
-        newSet.orderMap.set(set.snapshot[i].candName, newSet.snapshot.length);
-        newSet.snapshot.push(set.snapshot[i]);
-      }
-    }
-
-    return newSet;
-  }
-
   private computeNextSnapshot(
     candsInfo: CandidateInfo[],
     set: TimestampLowerBoundSet

--- a/step-release-vis/src/app/services/environment.ts
+++ b/step-release-vis/src/app/services/environment.ts
@@ -59,6 +59,30 @@ export class EnvironmentService {
     return new Polygon(points, candidate);
   }
 
+  private closePolygons(
+    polys: Polygon[],
+    lower: Map<string, Point[]>,
+    upper: Map<string, Point[]>,
+    set: TimestampUpperBoundSet
+  ): TimestampUpperBoundSet {
+    const newSet: TimestampUpperBoundSet = new TimestampUpperBoundSet();
+
+    for (let i = 0; i < set.snapshot.length; i++) {
+      if (
+        set.snapshot[i].position ===
+        (i === 0 ? 0 : set.snapshot[i - 1].position)
+      ) {
+        const name: string = set.snapshot[i].candName;
+        polys.push(this.createPolygon(lower.get(name), upper.get(name), name));
+      } else {
+        newSet.orderMap.set(set.snapshot[i].candName, newSet.snapshot.length);
+        newSet.snapshot.push(set.snapshot[i]);
+      }
+    }
+
+    return newSet;
+  }
+
   private computeNextSnapshot(
     candsInfo: CandidateInfo[],
     set: TimestampUpperBoundSet

--- a/step-release-vis/src/app/services/environment.ts
+++ b/step-release-vis/src/app/services/environment.ts
@@ -51,7 +51,7 @@ export class EnvironmentService {
     points.pop();
 
     const revUpperBound = upperBound.reverse();
-    for (const point of revUpperBound) {
+    for (const point of upperBound) {
       points.push(point);
     }
     points.pop();
@@ -62,18 +62,18 @@ export class EnvironmentService {
   private closePolygons(
     polys: Polygon[],
     lower: Map<string, Point[]>,
-    upper: Map<string, Point[]>,
-    set: TimestampUpperBoundSet
-  ): TimestampUpperBoundSet {
-    const newSet: TimestampUpperBoundSet = new TimestampUpperBoundSet();
+    Lower: Map<string, Point[]>,
+    set: TimestampLowerBoundSet
+  ): TimestampLowerBoundSet {
+    const newSet: TimestampLowerBoundSet = new TimestampLowerBoundSet();
 
     for (let i = 0; i < set.snapshot.length; i++) {
       if (
         set.snapshot[i].position ===
-        (i === 0 ? 0 : set.snapshot[i - 1].position)
+        (i === set.snapshot.length - 1 ? 100 : set.snapshot[i + 1].position)
       ) {
         const name: string = set.snapshot[i].candName;
-        polys.push(this.createPolygon(lower.get(name), upper.get(name), name));
+        polys.push(this.createPolygon(lower.get(name), Lower.get(name), name));
       } else {
         newSet.orderMap.set(set.snapshot[i].candName, newSet.snapshot.length);
         newSet.snapshot.push(set.snapshot[i]);
@@ -85,10 +85,10 @@ export class EnvironmentService {
 
   private computeNextSnapshot(
     candsInfo: CandidateInfo[],
-    set: TimestampUpperBoundSet
-  ): [TimestampUpperBoundSet, number] {
+    set: TimestampLowerBoundSet
+  ): [TimestampLowerBoundSet, number] {
     const percentages = this.getPercentages(candsInfo);
-    const newSet: TimestampUpperBoundSet = set;
+    const newSet: TimestampLowerBoundSet = set;
 
     for (let i = 0; i < set.snapshot.length; i++) {
       if (percentages.has(set.snapshot[i].candName)) {
@@ -107,15 +107,16 @@ export class EnvironmentService {
         newCandidates++;
         newSet.orderMap.set(entry[0], newSet.snapshot.length);
         newSet.snapshot.push(
-          new PolygonUpperBoundYPosition(entry[0], entry[1])
+          new PolygonLowerBoundYPosition(entry[0], entry[1])
         );
       }
     }
 
-    let sum = 0;
-    for (const candidate of newSet.snapshot) {
-      sum += candidate.position;
-      candidate.position = sum;
+    // if all candidates have 0 jobs they should all point at 100
+    let currentPosition = 100;
+    for (let i = newSet.snapshot.length - 1; i >= 0; i--) {
+      currentPosition -= newSet.snapshot[i].position;
+      newSet.snapshot[i].position = currentPosition;
     }
     return [newSet, newCandidates];
   }
@@ -126,6 +127,10 @@ export class EnvironmentService {
 
     for (const candInfo of candsInfo) {
       totalJobSum += candInfo.job_count;
+    }
+
+    if (totalJobSum === 0) {
+      totalJobSum = 1; // avoid division by 0, all candidates will have 0% of the jobs.
     }
 
     for (const candInfo of candsInfo) {
@@ -141,11 +146,11 @@ export class EnvironmentService {
   }
 }
 
-export class TimestampUpperBoundSet {
+export class TimestampLowerBoundSet {
   /* What is the order of the polygons? */
   orderMap: Map<string, number>;
   /* Store the details about each _active_ polygon */
-  snapshot: PolygonUpperBoundYPosition[];
+  snapshot: PolygonLowerBoundYPosition[];
 
   constructor() {
     this.orderMap = new Map();
@@ -153,7 +158,7 @@ export class TimestampUpperBoundSet {
   }
 }
 
-export class PolygonUpperBoundYPosition {
+export class PolygonLowerBoundYPosition {
   candName: string;
   position: number;
 

--- a/step-release-vis/src/app/services/environment.ts
+++ b/step-release-vis/src/app/services/environment.ts
@@ -62,7 +62,7 @@ export class EnvironmentService {
   private closePolygons(
     polys: Polygon[],
     lower: Map<string, Point[]>,
-    Lower: Map<string, Point[]>,
+    upper: Map<string, Point[]>,
     set: TimestampLowerBoundSet
   ): TimestampLowerBoundSet {
     const newSet: TimestampLowerBoundSet = new TimestampLowerBoundSet();
@@ -73,7 +73,7 @@ export class EnvironmentService {
         (i === set.snapshot.length - 1 ? 100 : set.snapshot[i + 1].position)
       ) {
         const name: string = set.snapshot[i].candName;
-        polys.push(this.createPolygon(lower.get(name), Lower.get(name), name));
+        polys.push(this.createPolygon(lower.get(name), upper.get(name), name));
       } else {
         newSet.orderMap.set(set.snapshot[i].candName, newSet.snapshot.length);
         newSet.snapshot.push(set.snapshot[i]);

--- a/step-release-vis/src/app/services/environment_test.ts
+++ b/step-release-vis/src/app/services/environment_test.ts
@@ -27,7 +27,7 @@ describe('EnvironmentService', () => {
       {x: 10, y: 0},
       {x: 10, y: 10},
     ];
-    const Lower: Point[] = [
+    const upper: Point[] = [
       {x: 0, y: 0},
       {x: 0, y: 10},
       {x: 10, y: 10},
@@ -43,7 +43,7 @@ describe('EnvironmentService', () => {
     );
 
     // @ts-ignore
-    const result: Polygon = service.createPolygon(lower, Lower, 'square');
+    const result: Polygon = service.createPolygon(lower, upper, 'square');
 
     expect(result).toEqual(square);
   });
@@ -53,7 +53,7 @@ describe('EnvironmentService', () => {
       {x: 0, y: 0},
       {x: 10, y: 10},
     ];
-    const Lower: Point[] = lower;
+    const upper: Point[] = lower;
     const line: Polygon = new Polygon(
       [
         {x: 0, y: 0},
@@ -63,7 +63,7 @@ describe('EnvironmentService', () => {
     );
 
     // @ts-ignore
-    const result: Polygon = service.createPolygon(lower, Lower, 'line');
+    const result: Polygon = service.createPolygon(lower, upper, 'line');
 
     expect(result).toEqual(line);
   });

--- a/step-release-vis/src/app/services/environment_test.ts
+++ b/step-release-vis/src/app/services/environment_test.ts
@@ -127,6 +127,30 @@ describe('EnvironmentService', () => {
     expect(result[0]).toBe(inputSet);
   });
 
+  it('#computeNextSnapshot all candidates have 0 jobs', () => {
+    const emptyCandInfo: CandidateInfo[] = [
+      {name: '1', job_count: 0},
+      {name: '2', job_count: 0},
+    ];
+    const inputSet: TimestampLowerBoundSet = new TimestampLowerBoundSet();
+    inputSet.orderMap.set('1', 0);
+    inputSet.orderMap.set('2', 1);
+    inputSet.snapshot[0] = new PolygonLowerBoundYPosition('1', 0);
+    inputSet.snapshot[1] = new PolygonLowerBoundYPosition('2', 50);
+
+    const outputSet: TimestampLowerBoundSet = inputSet;
+    outputSet.snapshot[0] = new PolygonLowerBoundYPosition('1', 100);
+    outputSet.snapshot[1] = new PolygonLowerBoundYPosition('2', 100);
+
+    const result: [
+      TimestampLowerBoundSet,
+      number
+      // @ts-ignore
+    ] = service.computeNextSnapshot(emptyCandInfo, inputSet);
+
+    expect(result).toEqual([outputSet, 0]);
+  });
+
   it('#computeNextSnapshot with old TimestampLowerBoundSet empty', () => {
     const inputCandInfo: CandidateInfo[] = [
       {name: '1', job_count: 105},
@@ -177,5 +201,17 @@ describe('EnvironmentService', () => {
     const resultMap: Map<string, number> = service.getPercentages([]);
 
     expect(resultMap.size).toBe(0);
+  });
+
+  it('#getPercenatges where all candidates have 0 jobs', () => {
+    // @ts-ignore
+    const resultMap: Map<string, number> = service.getPercentages([
+      {name: '1', job_count: 0},
+      {name: '2', job_count: 0},
+    ]);
+
+    expect(resultMap.size).toBe(2);
+    expect(resultMap.get('1')).toEqual(0);
+    expect(resultMap.get('2')).toEqual(0);
   });
 });

--- a/step-release-vis/src/app/services/environment_test.ts
+++ b/step-release-vis/src/app/services/environment_test.ts
@@ -2,8 +2,8 @@ import {TestBed} from '@angular/core/testing';
 
 import {
   EnvironmentService,
-  PolygonUpperBoundYPosition,
-  TimestampUpperBoundSet,
+  PolygonLowerBoundYPosition,
+  TimestampLowerBoundSet,
 } from './environment';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {CandidateInfo} from '../models/Data';
@@ -27,7 +27,7 @@ describe('EnvironmentService', () => {
       {x: 10, y: 0},
       {x: 10, y: 10},
     ];
-    const upper: Point[] = [
+    const Lower: Point[] = [
       {x: 0, y: 0},
       {x: 0, y: 10},
       {x: 10, y: 10},
@@ -43,7 +43,7 @@ describe('EnvironmentService', () => {
     );
 
     // @ts-ignore
-    const result: Polygon = service.createPolygon(lower, upper, 'square');
+    const result: Polygon = service.createPolygon(lower, Lower, 'square');
 
     expect(result).toEqual(square);
   });
@@ -53,7 +53,7 @@ describe('EnvironmentService', () => {
       {x: 0, y: 0},
       {x: 10, y: 10},
     ];
-    const upper: Point[] = lower;
+    const Lower: Point[] = lower;
     const line: Polygon = new Polygon(
       [
         {x: 0, y: 0},
@@ -63,7 +63,7 @@ describe('EnvironmentService', () => {
     );
 
     // @ts-ignore
-    const result: Polygon = service.createPolygon(lower, upper, 'line');
+    const result: Polygon = service.createPolygon(lower, Lower, 'line');
 
     expect(result).toEqual(line);
   });
@@ -97,29 +97,29 @@ describe('EnvironmentService', () => {
       {name: '1', job_count: 100},
       {name: '2', job_count: 100},
     ];
-    const inputSet: TimestampUpperBoundSet = new TimestampUpperBoundSet();
+    const inputSet: TimestampLowerBoundSet = new TimestampLowerBoundSet();
     inputSet.orderMap.set('1', 0);
-    inputSet.snapshot[0] = new PolygonUpperBoundYPosition('1', 100);
+    inputSet.snapshot[0] = new PolygonLowerBoundYPosition('1', 0);
 
     const result: [
-      TimestampUpperBoundSet,
+      TimestampLowerBoundSet,
       number
       // @ts-ignore
     ] = service.computeNextSnapshot(inputCandInfo, inputSet);
 
-    expect(result[0].snapshot[0].position).toEqual(50);
-    expect(result[0].snapshot[1].position).toEqual(100);
+    expect(result[0].snapshot[0].position).toEqual(0);
+    expect(result[0].snapshot[1].position).toEqual(50);
     expect(result[1]).toEqual(1);
   });
 
   it('#computeNextSnapshot candidate info list is empty', () => {
     const emptyCandInfo: CandidateInfo[] = [];
-    const inputSet: TimestampUpperBoundSet = new TimestampUpperBoundSet();
+    const inputSet: TimestampLowerBoundSet = new TimestampLowerBoundSet();
     inputSet.orderMap.set('1', 0);
-    inputSet.snapshot[0] = new PolygonUpperBoundYPosition('1', 100);
+    inputSet.snapshot[0] = new PolygonLowerBoundYPosition('1', 0);
 
     const result: [
-      TimestampUpperBoundSet,
+      TimestampLowerBoundSet,
       number
       // @ts-ignore
     ] = service.computeNextSnapshot(emptyCandInfo, inputSet);
@@ -127,23 +127,23 @@ describe('EnvironmentService', () => {
     expect(result[0]).toBe(inputSet);
   });
 
-  it('#computeNextSnapshot with old TimestampUpperBoundSet empty', () => {
+  it('#computeNextSnapshot with old TimestampLowerBoundSet empty', () => {
     const inputCandInfo: CandidateInfo[] = [
       {name: '1', job_count: 105},
       {name: '2', job_count: 300},
       {name: '3', job_count: 595},
     ];
-    const emptySet: TimestampUpperBoundSet = new TimestampUpperBoundSet();
+    const emptySet: TimestampLowerBoundSet = new TimestampLowerBoundSet();
 
     const result: [
-      TimestampUpperBoundSet,
+      TimestampLowerBoundSet,
       number
       // @ts-ignore
     ] = service.computeNextSnapshot(inputCandInfo, emptySet);
 
-    expect(result[0].snapshot[0].position).toEqual(10.5);
-    expect(result[0].snapshot[1].position).toEqual(40.5);
-    expect(result[0].snapshot[2].position).toEqual(100);
+    expect(result[0].snapshot[0].position).toEqual(0);
+    expect(result[0].snapshot[1].position).toEqual(10.5);
+    expect(result[0].snapshot[2].position).toEqual(40.5);
     expect(result[1]).toEqual(3);
   });
 


### PR DESCRIPTION
This helps treat the special case where all candidates have 0 jobs. With this version there is no need for a special part of code to treat the case.
In the previous verison, I considered that the bottom line is always the border of a polygon. Since we are inserting new polygons from the top, then the top line should be our focus.