### PR TITLE
Change color choosing algorithm.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -2,8 +2,7 @@
   <polygon
     *ngFor="let polygon of polygons"
     [attr.points]="polygon.toAttributeString()"
-    [attr.fill]="polygon.color"
-    [attr.opacity]="polygon.highlight ? 1.0 : 0.7"
+    [attr.fill]="getColor(polygon)"
     (mouseenter)="polygonMouseEnter(polygon)"
     (mouseleave)="polygonMouseLeave(polygon)"
   >

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -5,7 +5,6 @@ import {random} from 'lodash';
 import {ActivatedRoute} from '@angular/router';
 import {ParamService} from '../../services/param';
 import {Point} from '../../models/Point';
-import {EnvironmentServiceStub} from '../../../testing/EnvironmentServiceStub';
 
 @Component({
   selector: 'app-environment',
@@ -37,7 +36,7 @@ export class EnvironmentComponent implements OnInit {
 
     this.paramService.param(this.route, 'jsonFile', '').subscribe(jsonFile => {
       this.jsonFile = jsonFile;
-      new EnvironmentServiceStub()
+      this.environmentService
         .getPolygons(this.jsonFile)
         .subscribe(polygons => this.processPolygons(polygons));
     });

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -5,6 +5,7 @@ import {random} from 'lodash';
 import {ActivatedRoute} from '@angular/router';
 import {ParamService} from '../../services/param';
 import {Point} from '../../models/Point';
+import {EnvironmentServiceStub} from '../../../testing/EnvironmentServiceStub';
 
 @Component({
   selector: 'app-environment',
@@ -36,7 +37,7 @@ export class EnvironmentComponent implements OnInit {
 
     this.paramService.param(this.route, 'jsonFile', '').subscribe(jsonFile => {
       this.jsonFile = jsonFile;
-      this.environmentService
+      new EnvironmentServiceStub()
         .getPolygons(this.jsonFile)
         .subscribe(polygons => this.processPolygons(polygons));
     });
@@ -66,7 +67,7 @@ export class EnvironmentComponent implements OnInit {
         0,
         100
       );
-      scaledPolygon.color = this.getRandomColor();
+      scaledPolygon.colorHue = this.getRandomHue();
       return scaledPolygon;
     });
   }
@@ -144,14 +145,23 @@ export class EnvironmentComponent implements OnInit {
   }
 
   /**
-   * Generates a random hex color.
+   * Generates an HSL color based on the provided polygon.
+   * Hue is set to polygon's hue.
+   * Saturation is set to 100%, if the polygon is highlighted, 60% - otherwise
+   * Lightness is set to 50% to provide vibrant colors.
+   *
+   * @param polygon the polygon to generate the color for.
    */
-  private getRandomColor(): string {
-    const r = random(0, 255);
-    const g = random(0, 255);
-    const b = random(0, 255);
-    const toHexPadded = (value: number) => value.toString(16).padStart(2, '0');
-    return `#${toHexPadded(r)}${toHexPadded(g)}${toHexPadded(b)}`;
+  getColor(polygon: Polygon): string {
+    const saturation = polygon.highlight ? '100%' : '60%';
+    return `hsl(${polygon.colorHue}, ${saturation}, 50%)`;
+  }
+
+  /**
+   * Generates a random hue for an HSL color.
+   */
+  private getRandomHue(): number {
+    return random(0, 359);
   }
 
   polygonMouseEnter(polygon: Polygon): void {

--- a/step-release-vis/src/app/components/environment/environment_test.ts
+++ b/step-release-vis/src/app/components/environment/environment_test.ts
@@ -54,8 +54,9 @@ describe('EnvironmentComponent', () => {
 
   it('colors should be assigned', () => {
     fixture.detectChanges();
-    component.polygons.forEach(({color}) => {
-      expect(color).toMatch(/^#[0-9a-f]{6}$/);
+    component.polygons.forEach(({colorHue}) => {
+      expect(colorHue).toBeLessThan(360);
+      expect(colorHue).toBeGreaterThanOrEqual(0);
     });
   });
 

--- a/step-release-vis/src/app/models/Polygon.ts
+++ b/step-release-vis/src/app/models/Polygon.ts
@@ -3,13 +3,13 @@ import {Point} from './Point';
 export class Polygon {
   points: Point[];
   candName: string;
-  color: string;
+  colorHue?: number;
   highlight = false;
 
-  constructor(points: Point[], candName: string, color = 'black') {
+  constructor(points: Point[], candName: string, colorHue?: number) {
     this.points = points;
     this.candName = candName;
-    this.color = color;
+    this.colorHue = colorHue;
   }
 
   toAttributeString(): string {


### PR DESCRIPTION
* Replace random RGB colors with partially random HSL colors. This way the generated colors are bright and avoid black/white shades:
  - Hue is chosen randomly between 0-360 and this number is now the only polygon's color related property, instead of the full color
  - Saturation is set 100% for maximum vibrancy and lightness to 50% to be furthest from black and white
* Update event listeners to set saturation to 60% by default and to 100% if hovered. This way the polygons are not too bright by default, but highlighted on hover

