### PR TITLE
Make colors index based instead of random.

### DIFF
--- a/step-release-vis/src/testing/EnvironmentServiceStub.ts
+++ b/step-release-vis/src/testing/EnvironmentServiceStub.ts
@@ -3,7 +3,9 @@ import {Observable, of} from 'rxjs';
 import {Polygon} from '../app/models/Polygon';
 import {EnvironmentService} from '../app/services/environment';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class EnvironmentServiceStub {
   candName = 'test';
 

--- a/step-release-vis/src/testing/EnvironmentServiceStub.ts
+++ b/step-release-vis/src/testing/EnvironmentServiceStub.ts
@@ -24,6 +24,54 @@ export class EnvironmentServiceStub {
       ],
       this.candName
     ),
+    new Polygon(
+      [
+        {x: 100, y: 0},
+        {x: 100, y: 100},
+        {x: 200, y: 0},
+      ],
+      this.candName
+    ),
+    new Polygon(
+      [
+        {x: 100, y: 100},
+        {x: 200, y: 100},
+        {x: 200, y: 0},
+      ],
+      this.candName
+    ),
+    new Polygon(
+      [
+        {x: 200, y: 0},
+        {x: 200, y: 100},
+        {x: 300, y: 0},
+      ],
+      this.candName
+    ),
+    new Polygon(
+      [
+        {x: 200, y: 100},
+        {x: 300, y: 100},
+        {x: 300, y: 0},
+      ],
+      this.candName
+    ),
+    new Polygon(
+      [
+        {x: 300, y: 0},
+        {x: 300, y: 100},
+        {x: 400, y: 0},
+      ],
+      this.candName
+    ),
+    new Polygon(
+      [
+        {x: 300, y: 100},
+        {x: 400, y: 100},
+        {x: 400, y: 0},
+      ],
+      this.candName
+    ),
   ];
 
   getPolygons(jsonFile: string): Observable<Polygon[]> {


### PR DESCRIPTION
* Make colors index based, instead of random. The hue is evenly spread out across 0..360 and assigned to random polygons in single environment. 
e.g. amount = 4:
0 -> |--0--|--1--|--2--|--3--| <- 360
* Add more polygons to stub.