### PR TITLE
Move to HashLocationStrategy.

### DIFF
--- a/step-release-vis/src/app/app.module.ts
+++ b/step-release-vis/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
+import {HashLocationStrategy, LocationStrategy} from '@angular/common';
 
 import {AppComponent} from './app.component';
 import {AppRoutingModule} from './app-routing.module';
@@ -20,7 +21,7 @@ import {EnvironmentsComponent} from './components/environments/environments';
     EnvironmentsComponent,
   ],
   imports: [BrowserModule, AppRoutingModule, HttpClientModule],
-  providers: [],
+  providers: [{provide: LocationStrategy, useClass: HashLocationStrategy}],
   bootstrap: [AppComponent],
 })
 export class AppModule {}


### PR DESCRIPTION
* Previously used PathLocationStrategy would search for a folder when accessed directly and not through a routerLink, which would lead to 404s.