### PR TITLE
Tweak environment and timeline styling.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.css
+++ b/step-release-vis/src/app/components/environment/environment.css
@@ -1,6 +1,7 @@
 .environment-title {
   color: dimgrey;
   margin-bottom: 0;
+  margin-top: 0;
   font-family: "Courier New", sans-serif;
 }
 

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -7,28 +7,39 @@
         *ngFor="let polygon of polygons"
         [attr.points]="polygon.toAttributeString()"
         [attr.fill]="getColor(polygon)"
+        [attr.fill-opacity]="getOpacity(polygon)"
         (mouseenter)="polygonMouseEnter(polygon)"
         (mouseleave)="polygonMouseLeave(polygon)"
       >
       </polygon>
-      <rect [attr.x]="0" [attr.y]="svgHeight - TIMELINE_HEIGHT / 2 - 5" [attr.width]="svgWidth" [attr.height]="2"
+      <rect [attr.x]="0" [attr.y]="svgHeight - TIMELINE_HEIGHT + 10" [attr.width]="svgWidth" [attr.height]="2"
             fill="gray"/>
       <text
         *ngFor="let timelinePoint of timelinePoints; let i = index"
         [attr.x]="timelinePoint.x"
-        [attr.y]="svgHeight - 3"
+        [attr.y]="svgHeight - 12"
         [attr.text-anchor]="getTimelinePointTextAlignment(i)"
         font-family="Roboto, Arial, sans-serif"
         font-size="12"
       >
-        {{ timelinePoint.timestampString }}
+        {{ timelinePoint.timeString }}
+      </text>
+      <text
+        *ngFor="let timelinePoint of timelinePoints; let i = index"
+        [attr.x]="timelinePoint.x"
+        [attr.y]="svgHeight"
+        [attr.text-anchor]="getTimelinePointTextAlignment(i)"
+        font-family="Roboto, Arial, sans-serif"
+        font-size="12"
+      >
+        {{ timelinePoint.dateString }}
       </text>
       <line
         *ngFor="let timelinePoint of timelinePoints"
         [attr.x1]="timelinePoint.x"
         [attr.y1]="svgHeight - TIMELINE_HEIGHT + 2"
         [attr.x2]="timelinePoint.x"
-        [attr.y2]="svgHeight - TIMELINE_HEIGHT / 2 + 2"
+        [attr.y2]="svgHeight - TIMELINE_HEIGHT / 2 - 3"
         stroke="gray"
       />
     </svg>

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -12,7 +12,7 @@ import {TimelinePoint} from '../../models/TimelinePoint';
   styleUrls: ['./environment.css'],
 })
 export class EnvironmentComponent implements OnInit {
-  readonly TIMELINE_HEIGHT = 30;
+  readonly TIMELINE_HEIGHT = 40;
   readonly SNAPSHOTS_PER_ENV = 100;
 
   @Input() svgWidth: number;
@@ -135,6 +135,17 @@ export class EnvironmentComponent implements OnInit {
     return `hsl(${polygon.colorHue}, ${saturation}, 50%)`;
   }
 
+  /**
+   * Returns an opacity value based on polygons highlight property.
+   *
+   * @param polygon the polygon
+   */
+  getOpacity(polygon: Polygon): string {
+    return polygon.highlight ? '1.0' : '0.7';
+  }
+
+  // TODO(ancar): Fix the highlighting.
+
   polygonMouseEnter(polygon: Polygon): void {
     this.candidateService.polygonHovered(polygon);
   }
@@ -151,4 +162,18 @@ export class EnvironmentComponent implements OnInit {
     }
     return 'middle';
   }
+
+  showTooltip(event: MouseEvent, polygon: Polygon): void {
+    const tooltip = document.getElementById('tooltip');
+    const rapidLink: string =
+      '<a href="' + 'https://rapid/' + polygon.candName + '">See on rapid</a>';
+    const innerHTML: string =
+      'Name of candidate: ' + polygon.candName + '<br>' + rapidLink;
+    tooltip.innerHTML = innerHTML;
+    tooltip.style.display = 'block';
+    tooltip.style.top = event.pageY.toString() + 'px';
+    tooltip.style.left = event.pageX.toString() + 'px';
+  }
+
+  // TODO(ancar): Add method for the tooltip to disappear correctly.
 }

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -144,8 +144,6 @@ export class EnvironmentComponent implements OnInit {
     return polygon.highlight ? '1.0' : '0.7';
   }
 
-  // TODO(ancar): Fix the highlighting.
-
   polygonMouseEnter(polygon: Polygon): void {
     this.candidateService.polygonHovered(polygon);
   }
@@ -162,18 +160,4 @@ export class EnvironmentComponent implements OnInit {
     }
     return 'middle';
   }
-
-  showTooltip(event: MouseEvent, polygon: Polygon): void {
-    const tooltip = document.getElementById('tooltip');
-    const rapidLink: string =
-      '<a href="' + 'https://rapid/' + polygon.candName + '">See on rapid</a>';
-    const innerHTML: string =
-      'Name of candidate: ' + polygon.candName + '<br>' + rapidLink;
-    tooltip.innerHTML = innerHTML;
-    tooltip.style.display = 'block';
-    tooltip.style.top = event.pageY.toString() + 'px';
-    tooltip.style.left = event.pageX.toString() + 'px';
-  }
-
-  // TODO(ancar): Add method for the tooltip to disappear correctly.
 }

--- a/step-release-vis/src/app/components/environments/environments.ts
+++ b/step-release-vis/src/app/components/environments/environments.ts
@@ -14,7 +14,7 @@ import {TimelinePoint} from '../../models/TimelinePoint';
 export class EnvironmentsComponent implements OnInit {
   readonly ENVS_PER_PAGE = 7;
   readonly ENV_RIGHT_MARGIN = 100;
-  readonly TIMELINE_POINT_WIDTH = 200;
+  readonly TIMELINE_POINT_WIDTH = 130;
   readonly WEEK_SECONDS = 7 * 24 * 60 * 60;
 
   environments: Environment[];
@@ -117,7 +117,8 @@ export class EnvironmentsComponent implements OnInit {
     const timelineChunkSize =
       (this.endTimestamp - this.startTimestamp) / this.timelinePointsAmount;
     for (let i = 0; i <= this.timelinePointsAmount; i++) {
-      const relativeTimestamp = timelineChunkSize * i;
+      let relativeTimestamp = timelineChunkSize * i;
+      relativeTimestamp = Math.floor(relativeTimestamp / 60) * 60; // Round seconds
       this.timelinePoints.push(
         new TimelinePoint(
           this.startTimestamp + relativeTimestamp,

--- a/step-release-vis/src/app/models/TimelinePoint.ts
+++ b/step-release-vis/src/app/models/TimelinePoint.ts
@@ -1,13 +1,16 @@
 export class TimelinePoint {
   timestamp: number;
   x: number;
-  timestampString: string;
+  timeString: string;
+  dateString: string;
 
   constructor(timestamp: number, x: number) {
     this.timestamp = timestamp;
     this.x = x;
-    this.timestampString = new Date(this.timestamp * 1000).toLocaleString(
-      'en-GB'
-    );
+    const dateTime = new Date(this.timestamp * 1000)
+      .toLocaleString('en-GB')
+      .split(', ');
+    this.dateString = dateTime[0];
+    this.timeString = dateTime[1];
   }
 }


### PR DESCRIPTION
* Reduce default polygon opacity
* Add two-line timestamps on timeline
* Increase timeline timestamp frequency. Round seconds

| Before | After |
| :-----: | :----: |
| ![image](https://user-images.githubusercontent.com/35143083/91591134-17e3df80-e965-11ea-9a8e-197ecb02c23a.png) | ![image](https://user-images.githubusercontent.com/35143083/91698090-d3ca2800-eb7a-11ea-8422-637511fcd3b7.png)|