### PR TITLE
Fix tooltip behaviour. Add vertical line for current snapshot.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.css
+++ b/step-release-vis/src/app/components/environment/environment.css
@@ -13,6 +13,11 @@
   font-family: "Courier New", sans-serif;
 }
 
+#cur-snapshot-line {
+  pointer-events: none;
+  mix-blend-mode: difference;
+}
+
 #tooltip {
   width: 10%;
   height: 10%;

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -1,7 +1,11 @@
 <div class="environment-container">
   <p class="environment-title"> {{environment.name}} </p>
   <div>
-    <app-tooltip [tooltip]="tooltip" [currentSnapshot]="currentSnapshot"></app-tooltip>
+    <app-tooltip
+      *ngIf="tooltip.show"
+      [tooltip]="tooltip"
+      [currentSnapshot]="currentSnapshot"
+    ></app-tooltip>
     <svg id="{{environment.name}}-svg" xmlns="http://www.w3.org/2000/svg" [attr.width]="svgWidth" [attr.height]="svgHeight"
          (mouseenter)="enteredEnvironment($event)"
          (mouseleave)="leftEnvironment($event)"

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -15,6 +15,15 @@
         (mouseleave)="leftPolygon(polygon)"
       >
       </polygon>
+      <rect
+        *ngIf="currentSnapshot"
+        id="cur-snapshot-line"
+        [attr.x]="getLineX() - 1"
+        [attr.y]="0"
+        [attr.width]="2"
+        [attr.height]="svgHeight - TIMELINE_HEIGHT + 10"
+        fill="white"
+      />
       <rect [attr.x]="0" [attr.y]="svgHeight - TIMELINE_HEIGHT + 10" [attr.width]="svgWidth" [attr.height]="2"
             fill="gray"/>
       <text

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -256,4 +256,14 @@ export class EnvironmentComponent implements OnInit, OnChanges {
 
     this.currentSnapshot = this.displayedSnapshots[index];
   }
+
+  getLineX(): number {
+    return this.candidateService.scale(
+      this.currentSnapshot.timestamp.seconds,
+      this.startTimestamp,
+      this.endTimestamp,
+      0,
+      this.svgWidth
+    );
+  }
 }

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -202,6 +202,7 @@ export class EnvironmentComponent implements OnInit, OnChanges {
 
   leftEnvironment(event: MouseEvent): void {
     this.hideTooltip();
+    this.currentSnapshot = undefined;
   }
 
   hideTooltip(): void {
@@ -226,7 +227,9 @@ export class EnvironmentComponent implements OnInit, OnChanges {
     let index = Math.floor(
       (svgMouseX * (this.displayedSnapshots.length - 1)) / this.svgWidth
     );
-
+    if (index < 0) {
+      return;
+    }
     const firstTimestamp = this.displayedSnapshots[0].timestamp.seconds;
     const lastTimestamp = this.displayedSnapshots[
       this.displayedSnapshots.length - 1

--- a/step-release-vis/src/app/components/environment/environment_test.ts
+++ b/step-release-vis/src/app/components/environment/environment_test.ts
@@ -183,4 +183,18 @@ describe('EnvironmentComponent', () => {
       expect(component.currentSnapshot.timestamp.seconds).toEqual(11);
     });
   });
+
+  it('tooltip should be shown when flag is true', () => {
+    component.tooltip.show = true;
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('app-tooltip'))).toBeTruthy();
+
+    component.tooltip.show = false;
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('app-tooltip'))).toBeFalsy();
+  });
+
+  describe('current snapshot vertical line', () => {
+    // TODO(#237): add vertical line tests
+  });
 });

--- a/step-release-vis/src/app/components/tooltip/tooltip.css
+++ b/step-release-vis/src/app/components/tooltip/tooltip.css
@@ -1,6 +1,6 @@
 .tooltip {
   position: fixed;
-  display: none;
+  display: block;
 
   padding: 10px;
 

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -7,8 +7,9 @@ import {Tooltip} from '../../models/Tooltip';
   templateUrl: './tooltip.html',
   styleUrls: ['./tooltip.css'],
 })
-export class TooltipComponent implements OnInit {@Input() tooltip: Tooltip = new Tooltip();
- @Input() currentSnapshot: Snapshot;
+export class TooltipComponent implements OnInit {
+  @Input() tooltip: Tooltip;
+  @Input() currentSnapshot: Snapshot;
   width = 200;
   height = 50;
 
@@ -19,7 +20,7 @@ export class TooltipComponent implements OnInit {@Input() tooltip: Tooltip = new
   ngOnInit(): void {}
 
   isReady(): boolean {
-    return this.tooltip.envName !== undefined;
+    return this.currentSnapshot !== undefined;
   }
 
   getData(): string {
@@ -56,15 +57,6 @@ export class TooltipComponent implements OnInit {@Input() tooltip: Tooltip = new
     return this.tooltip.mouseY + 20 + 'px';
   }
 
-  // make the tooltip visible or not
-  getShow(): string {
-    if (this.tooltip.show) {
-      return 'block';
-    } else {
-      return 'none';
-    }
-  }
-
   getWidth(): string {
     return this.width + 'px';
   }
@@ -81,7 +73,6 @@ export class TooltipComponent implements OnInit {@Input() tooltip: Tooltip = new
       style.height = this.getHeight();
       style.left = this.getLeft();
       style.top = this.getTop();
-      style.display = this.getShow();
     }
   }
 }

--- a/step-release-vis/src/app/components/tooltip/tooltip_test.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip_test.ts
@@ -50,13 +50,5 @@ describe('TooltipComponent', () => {
 
       expect(component.getTop()).toBe('520px');
     });
-
-    it('#getShow should be block when true and none when false', () => {
-      component.tooltip.show = true;
-      expect(component.getShow()).toBe('block');
-
-      component.tooltip.show = false;
-      expect(component.getShow()).toBe('none');
-    });
   });
 });

--- a/step-release-vis/src/app/components/tooltip/tooltip_test.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip_test.ts
@@ -32,23 +32,23 @@ describe('TooltipComponent', () => {
 
   describe('Compute tooltip location', () => {
     it('#getLeft should get a position with 20px added', () => {
-      component.tooltip.mouseX = 200;
+      component.tooltip.mouseX = 100;
       const div = fixture.debugElement.query(By.css('div'));
 
       component.getLeft();
       fixture.detectChanges();
 
-      expect(component.getLeft()).toBe('220px');
+      expect(component.getLeft()).toBe('120px');
     });
 
     it('#getTop should get a position with 20px added', () => {
-      component.tooltip.mouseY = 500;
+      component.tooltip.mouseY = 100;
       const div = fixture.debugElement.query(By.css('div'));
 
       component.getTop();
-      fixture.detectChanges();
 
-      expect(component.getTop()).toBe('520px');
+      fixture.detectChanges();
+      expect(component.getTop()).toBe('120px');
     });
   });
 });


### PR DESCRIPTION
* Replace display block/none with ngIf (field change wouldn't trigger style update).
* Update tooltip isReady()

* Add vertical line for current snapshot
  - The line follows the cursor and is positioned on the closest displayed timestamp
  - Add blending mode: `difference` to make the line bright on any background

![image](https://user-images.githubusercontent.com/35143083/92017675-cc627480-ed5c-11ea-9921-2d103a5c49af.png)
![image](https://user-images.githubusercontent.com/35143083/92017742-e13f0800-ed5c-11ea-9448-a144060e1ff4.png)

