### PR TITLE
Add data to the tooltip and change dimensions.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -1,7 +1,12 @@
 <div class="environment-container">
   <p class="environment-title"> {{environment.name}} </p>
   <div>
-    <app-tooltip [tooltip]="tooltip" [currentSnapshot]="currentSnapshot"></app-tooltip>
+    <app-tooltip
+        [tooltip]="tooltip"
+        [currentSnapshot]="currentSnapshot"
+        [currentCandidate]="currentCandidate"
+    >
+    </app-tooltip>
     <svg id="{{environment.name}}-svg" xmlns="http://www.w3.org/2000/svg" [attr.width]="svgWidth" [attr.height]="svgHeight" (mouseenter)="enteredEnvironment()">
       <polygon
         *ngFor="let polygon of polygons"

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -33,7 +33,9 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   polygons: Polygon[];
   tooltip: Tooltip = new Tooltip();
   displayedSnapshots: Snapshot[];
+
   currentSnapshot: Snapshot;
+  currentCandidate: string;
 
   constructor(
     private environmentService: EnvironmentService,
@@ -178,6 +180,7 @@ export class EnvironmentComponent implements OnInit, OnChanges {
 
   polygonMouseEnter(polygon: Polygon, event: MouseEvent): void {
     this.candidateService.polygonHovered(polygon);
+    this.currentCandidate = polygon.candName;
     this.moveTooltip(event);
   }
 

--- a/step-release-vis/src/app/components/tooltip/tooltip.css
+++ b/step-release-vis/src/app/components/tooltip/tooltip.css
@@ -2,9 +2,11 @@
   position: fixed;
   display: none;
 
-  width: 10%;
-  height: 20%;
+  width: 20%;
+  height: 15%;
   padding: 1%;
+
+  font-size: x-small;
 
   background-color: rgba(240, 240, 240, 0.8);
   border: 1px solid black;

--- a/step-release-vis/src/app/components/tooltip/tooltip.css
+++ b/step-release-vis/src/app/components/tooltip/tooltip.css
@@ -3,12 +3,14 @@
   display: none;
 
   padding: 10px;
-  width: 20%;
-  height: 15%;
 
   font-size: x-small;
 
   background-color: rgba(240, 240, 240, 0.8);
   border: 1px solid black;
   border-radius: 3px;
+}
+
+.h3 {
+  margin: 2px;
 }

--- a/step-release-vis/src/app/components/tooltip/tooltip.html
+++ b/step-release-vis/src/app/components/tooltip/tooltip.html
@@ -1,4 +1,4 @@
-<div class="tooltip" id="{{tooltip.envName}}">
+<div class="tooltip" id="{{tooltip.envName}}"
   *ngIf="isReady()"
   [innerHTML]="getData()">
 </div>

--- a/step-release-vis/src/app/components/tooltip/tooltip.html
+++ b/step-release-vis/src/app/components/tooltip/tooltip.html
@@ -1,4 +1,4 @@
 <div class="tooltip" id="{{tooltip.envName}}"
      [ngStyle]="{left: getLeft(), top: getTop(), display: getShow()}">
-  <p *ngIf="isReady()"> {{getData()}} </p>
+  <div *ngIf="isReady()"> {{getData()}} </div>
 </div>

--- a/step-release-vis/src/app/components/tooltip/tooltip.html
+++ b/step-release-vis/src/app/components/tooltip/tooltip.html
@@ -1,4 +1,5 @@
 <div class="tooltip" id="{{tooltip.envName}}"
-     [ngStyle]="{left: getLeft(), top: getTop(), display: getShow()}">
-  <div *ngIf="isReady()"> {{getData()}} </div>
+     *ngIf="isReady()"
+     [ngStyle]="{left: getLeft(), top: getTop(), display: getShow()}"
+     [innerHTML]="getData()">
 </div>

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -1,7 +1,6 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {Snapshot} from '../../models/Data';
 import {Tooltip} from '../../models/Tooltip';
-import {CandidateService} from '../../services/candidateService';
 
 @Component({
   selector: 'app-tooltip',
@@ -12,7 +11,7 @@ export class TooltipComponent implements OnInit {
   @Input() tooltip: Tooltip = new Tooltip();
   @Input() currentSnapshot: Snapshot;
 
-  constructor(private candidateService: CandidateService) {}
+  constructor() {}
 
   ngOnInit(): void {}
 
@@ -23,11 +22,10 @@ export class TooltipComponent implements OnInit {
   getData(): string {
     const dateTime: Date = new Date(
       this.currentSnapshot.timestamp.seconds * 1000
-    );
+    ).toLocaleString('en-GB');
     const localTimeZone: string = Intl.DateTimeFormat().resolvedOptions()
       .timeZone;
-    // TODO(#210): add other details
-    return dateTime.toLocaleString('en-GB') + ' ' + localTimeZone;
+    const currentTime: string = dateTime + ' ' + localTimeZone;
   }
 
   // computes the left position of the tooltip according to the mouse's X position

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -19,13 +19,23 @@ export class TooltipComponent implements OnInit {
     return this.tooltip.envName !== undefined;
   }
 
+  // Displayes date,time,local timezone and candidate info with rapid links.
   getData(): string {
     const dateTime: Date = new Date(
       this.currentSnapshot.timestamp.seconds * 1000
     ).toLocaleString('en-GB');
     const localTimeZone: string = Intl.DateTimeFormat().resolvedOptions()
       .timeZone;
-    const currentTime: string = dateTime + ' ' + localTimeZone;
+    const currentTime: string =
+      '<h3>' + dateTime + ' ' + localTimeZone + '</h3>';
+
+    const candidateInfo: string = '';
+    for (let candidate of this.currentSnapshot.candidatesList) {
+      candidate +=
+        '<p>' + candidate.candidate + ': ' + candidate.jobCount + '</p>';
+    }
+
+    return currentTime + candidateInfo;
   }
 
   // computes the left position of the tooltip according to the mouse's X position

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -21,7 +21,7 @@ export class TooltipComponent implements OnInit {
   }
 
   /* Displays date,time,local timezone and candidate info with rapid links.
-   *  Current candidate info is written in bold.
+   * Current candidate info is written in bold.
    */
   getData(): string {
     const dateTime: string = new Date(
@@ -37,7 +37,7 @@ export class TooltipComponent implements OnInit {
       const name: string = candidate.candidate;
       const link = `<a href=${'https://rapid/' + name}>${name}</a>`;
       let candidateDescription =
-        '<p>' + link + ': ' + candidate.jobCount + ' jobs</p>';
+        '<p>' + link + ': ' + candidate.jobCount + ' job(s)</p>';
 
       if (name === this.currentCandidate) {
         candidateDescription = `<b>${candidateDescription}</b>`;

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -12,9 +12,7 @@ export class TooltipComponent implements OnInit {
   @Input() currentSnapshot: Snapshot;
   @Input() currentCandidate: string;
   width = 200;
-  height = 50;
-
-  // TODO(#234): Compute width/height of the tooltip according to the data.
+  height = 30;
 
   constructor() {}
 
@@ -52,7 +50,7 @@ export class TooltipComponent implements OnInit {
 
     this.updateStyle();
     return currentTime + candidateInfo;
-}
+  }
 
   // computes the left position of the tooltip according to the mouse's X position
   getLeft(): string {
@@ -91,7 +89,7 @@ export class TooltipComponent implements OnInit {
   }
 
   getHeight(): string {
-    return this.height + 'px';
+    return this.height + 20 * this.currentSnapshot.candidatesList.length + 'px';
   }
 
   private updateStyle(): void {

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -10,6 +10,7 @@ import {Tooltip} from '../../models/Tooltip';
 export class TooltipComponent implements OnInit {
   @Input() tooltip: Tooltip = new Tooltip();
   @Input() currentSnapshot: Snapshot;
+  @Input() currentCandidate: string;
 
   constructor() {}
 
@@ -19,9 +20,11 @@ export class TooltipComponent implements OnInit {
     return this.tooltip.envName !== undefined;
   }
 
-  // Displayes date,time,local timezone and candidate info with rapid links.
+  /* Displays date,time,local timezone and candidate info with rapid links.
+   *  Current candidate info is written in bold.
+   */
   getData(): string {
-    const dateTime: Date = new Date(
+    const dateTime: string = new Date(
       this.currentSnapshot.timestamp.seconds * 1000
     ).toLocaleString('en-GB');
     const localTimeZone: string = Intl.DateTimeFormat().resolvedOptions()
@@ -29,10 +32,18 @@ export class TooltipComponent implements OnInit {
     const currentTime: string =
       '<h3>' + dateTime + ' ' + localTimeZone + '</h3>';
 
-    const candidateInfo: string = '';
-    for (let candidate of this.currentSnapshot.candidatesList) {
-      candidate +=
-        '<p>' + candidate.candidate + ': ' + candidate.jobCount + '</p>';
+    let candidateInfo = '';
+    for (const candidate of this.currentSnapshot.candidatesList) {
+      const name: string = candidate.candidate;
+      const link = `<a href=${'https://rapid/' + name}>${name}</a>`;
+      let candidateDescription =
+        '<p>' + link + ': ' + candidate.jobCount + ' jobs</p>';
+
+      if (name === this.currentCandidate) {
+        candidateDescription = `<b>${candidateDescription}</b>`;
+      }
+
+      candidateInfo += candidateDescription;
     }
 
     return currentTime + candidateInfo;

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -12,6 +12,7 @@ export class TooltipComponent implements OnInit {
   @Input() currentSnapshot: Snapshot;
   @Input() currentCandidate: string;
 
+  readonly PIXELS_PER_CAND = 20;
   width = 200;
   height = 30;
 
@@ -39,8 +40,7 @@ export class TooltipComponent implements OnInit {
     for (const candidate of this.currentSnapshot.candidatesList) {
       const name: string = candidate.candidate;
       const link = `<a href=${'https://rapid/' + name}>${name}</a>`;
-      let candidateDescription =
-        '<p>' + link + ': ' + candidate.jobCount + ' job(s)</p>';
+      let candidateDescription = `<p>${link}: ${candidate.jobCount} job(s)</p>`;
 
       if (name === this.currentCandidate) {
         candidateDescription = `<b>${candidateDescription}</b>`;
@@ -81,7 +81,11 @@ export class TooltipComponent implements OnInit {
   }
 
   getHeight(): string {
-    return this.height + 20 * this.currentSnapshot.candidatesList.length + 'px';
+    return (
+      this.height +
+      this.PIXELS_PER_CAND * this.currentSnapshot.candidatesList.length +
+      'px'
+    );
   }
 
   private updateStyle(): void {

--- a/step-release-vis/src/app/components/tooltip/tooltip_test.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip_test.ts
@@ -3,6 +3,7 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {TooltipComponent} from './tooltip';
 import {Tooltip} from '../../models/Tooltip';
 import {By} from '@angular/platform-browser';
+import {Candidate} from '../../models/Candidate';
 
 describe('TooltipComponent', () => {
   let component: TooltipComponent;
@@ -21,7 +22,7 @@ describe('TooltipComponent', () => {
     component.tooltip.envName = '1';
     component.currentSnapshot = {
       timestamp: {seconds: undefined, nanos: undefined},
-      candidatesList: undefined,
+      candidatesList: [],
     };
     fixture.detectChanges();
   });
@@ -57,6 +58,14 @@ describe('TooltipComponent', () => {
 
       component.tooltip.show = false;
       expect(component.getShow()).toBe('none');
+    });
+
+    it('#getHeight should add 20px for each candidate', () => {
+      component.currentSnapshot.candidatesList.push({
+        candidate: '',
+        jobCount: 0,
+      });
+      expect(component.getHeight()).toEqual('50px');
     });
   });
 });


### PR DESCRIPTION
* Add candidates details and links to rapid.
* Bold the currently hovered candidate.
* Change the dimensions of the tooltip depending on the content to be shown.

The following is when the current snapshot contains only one candidate:
![Screenshot 2020-09-02 at 8 44 13 PM](https://user-images.githubusercontent.com/68221093/92023886-14d26000-ed66-11ea-9936-b233c83205d0.png)

Here 2 candidates are displayed:
![Screenshot 2020-09-02 at 8 44 20 PM](https://user-images.githubusercontent.com/68221093/92023902-1a2faa80-ed66-11ea-966a-e7b38448ae99.png)
