### PR TITLE
Fix position of tooltip when the environment is clicked.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -6,7 +6,6 @@
       [tooltip]="tooltip"
       [currentSnapshot]="currentSnapshot"
       [currentCandidate]="currentCandidate"
-      (tooltipHovered)="setTooltipHovered($event)"
     ></app-tooltip>
     <svg id="{{environment.name}}-svg" xmlns="http://www.w3.org/2000/svg" [attr.width]="svgWidth" [attr.height]="svgHeight"
          (mouseenter)="enteredEnvironment($event)"

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -1,6 +1,6 @@
 <div class="environment-container">
   <p class="environment-title"> {{environment.name}} </p>
-  <div>
+  <div (mouseleave)="leaveDiv()">
     <app-tooltip
       *ngIf="tooltip.show"
       [tooltip]="tooltip"

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -9,7 +9,8 @@
     <svg id="{{environment.name}}-svg" xmlns="http://www.w3.org/2000/svg" [attr.width]="svgWidth" [attr.height]="svgHeight"
          (mouseenter)="enteredEnvironment($event)"
          (mouseleave)="leftEnvironment($event)"
-         (mousemove)="moveTooltip($event)">
+         (mousemove)="moveTooltip($event)"
+         (click)="updateClickOn()">
       <polygon
         *ngFor="let polygon of polygons"
         [attr.points]="polygon.toAttributeString()"

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -10,7 +10,7 @@
     ></app-tooltip>
     <svg id="{{environment.name}}-svg" xmlns="http://www.w3.org/2000/svg" [attr.width]="svgWidth" [attr.height]="svgHeight"
          (mouseenter)="enteredEnvironment($event)"
-         (mouseleave)="leftEnvironment($event)"
+         (mouseleave)="leftEnvironment()"
          (mousemove)="moveTooltip($event)"
          (click)="updateClickOn()"
     >

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -5,6 +5,7 @@
       *ngIf="tooltip.show"
       [tooltip]="tooltip"
       [currentSnapshot]="currentSnapshot"
+      (tooltipHovered)="setTooltipHovered($event)"
     ></app-tooltip>
     <svg id="{{environment.name}}-svg" xmlns="http://www.w3.org/2000/svg" [attr.width]="svgWidth" [attr.height]="svgHeight"
          (mouseenter)="enteredEnvironment($event)"

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -34,6 +34,7 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   tooltip: Tooltip = new Tooltip();
   displayedSnapshots: Snapshot[];
   currentSnapshot: Snapshot;
+  tooltipHovered: boolean;
 
   constructor(
     private environmentService: EnvironmentService,
@@ -205,12 +206,9 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   leftEnvironment(event: MouseEvent): void {
-    this.currentSnapshot = undefined;
-    if (!this.tooltip.clickOn && !this.tooltip.hoveredOver) {
+    if (!this.tooltip.clickOn) {
       this.hideTooltip();
-    } else if (this.tooltip.clickOn) {
-      this.hideTooltip();
-      this.updateClickOn();
+      this.currentSnapshot = undefined;
     }
   }
 
@@ -281,5 +279,9 @@ export class EnvironmentComponent implements OnInit, OnChanges {
 
   updateClickOn(): void {
     this.tooltip.clickOn = !this.tooltip.clickOn;
+  }
+
+  setTooltipHovered(value: boolean): void {
+    this.tooltipHovered = value;
   }
 }

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -34,8 +34,6 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   tooltip: Tooltip = new Tooltip();
   displayedSnapshots: Snapshot[];
   currentSnapshot: Snapshot;
-  // when clickOn is true, the tooltip and the line stop moving after the mouse
-  clickOn: boolean;
 
   constructor(
     private environmentService: EnvironmentService,
@@ -192,7 +190,7 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   moveTooltip(event: MouseEvent): void {
-    if (!this.clickOn) {
+    if (!this.tooltip.clickOn) {
       this.tooltip.mouseX = event.pageX - window.scrollX;
       this.tooltip.mouseY = event.pageY - window.scrollY;
       this.tooltip.show = true;
@@ -207,9 +205,13 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   leftEnvironment(event: MouseEvent): void {
-    this.hideTooltip();
     this.currentSnapshot = undefined;
-    this.clickOn = false;
+    if (!this.tooltip.clickOn && !this.tooltip.hoveredOver) {
+      this.hideTooltip();
+    } else if (this.tooltip.clickOn) {
+      this.hideTooltip();
+      this.updateClickOn();
+    }
   }
 
   hideTooltip(): void {
@@ -278,6 +280,6 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   updateClickOn(): void {
-    this.clickOn = !this.clickOn;
+    this.tooltip.clickOn = !this.tooltip.clickOn;
   }
 }

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -212,7 +212,7 @@ export class EnvironmentComponent implements OnInit, OnChanges {
 
   // TODO(ancar): Make it work for when it leaves the environment, not
   // it disappers only when you enter and then leave the tooltip.
-  leftEnvironment(event: MouseEvent): void {
+  leftEnvironment(): void {
     if (!this.tooltip.clickOn) {
       this.hideTooltip();
       this.currentSnapshot = undefined;

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -291,4 +291,12 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   setTooltipHovered(value: boolean): void {
     this.tooltipHovered = value;
   }
+
+  leaveDiv(): void {
+    if (!this.tooltipHovered) {
+      this.hideTooltip();
+      this.currentSnapshot = undefined;
+      this.tooltip.clickOn = false;
+    }
+  }
 }

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -187,10 +187,8 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   enteredEnvironment(event: MouseEvent): void {
-    if (!this.clickOn) {
-      this.tooltip.envName = this.environment.name;
-      this.moveTooltip(event);
-    }
+    this.tooltip.envName = this.environment.name;
+    this.moveTooltip(event);
   }
 
   moveTooltip(event: MouseEvent): void {
@@ -209,10 +207,9 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   leftEnvironment(event: MouseEvent): void {
-    if (!this.clickOn) {
-      this.hideTooltip();
-      this.currentSnapshot = undefined;
-    }
+    this.hideTooltip();
+    this.currentSnapshot = undefined;
+    this.clickOn = false;
   }
 
   hideTooltip(): void {

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -34,6 +34,8 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   tooltip: Tooltip = new Tooltip();
   displayedSnapshots: Snapshot[];
   currentSnapshot: Snapshot;
+  // when clickOn is true, the tooltip and the line stop moving after the mouse
+  clickOn: boolean;
 
   constructor(
     private environmentService: EnvironmentService,
@@ -185,24 +187,32 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   enteredEnvironment(event: MouseEvent): void {
-    this.tooltip.envName = this.environment.name;
-    this.moveTooltip(event);
+    if (!this.clickOn) {
+      this.tooltip.envName = this.environment.name;
+      this.moveTooltip(event);
+    }
   }
 
   moveTooltip(event: MouseEvent): void {
-    this.tooltip.mouseX = event.pageX - window.scrollX;
-    this.tooltip.mouseY = event.pageY - window.scrollY;
-    this.tooltip.show = true;
+    if (!this.clickOn) {
+      this.tooltip.mouseX = event.pageX - window.scrollX;
+      this.tooltip.mouseY = event.pageY - window.scrollY;
+      this.tooltip.show = true;
 
-    const svgElement = document.getElementById(this.environment.name + '-svg');
-    const svgMouseX = event.pageX - svgElement.getBoundingClientRect().left;
+      const svgElement = document.getElementById(
+        this.environment.name + '-svg'
+      );
+      const svgMouseX = event.pageX - svgElement.getBoundingClientRect().left;
 
-    this.updateCurrentSnapshot(svgMouseX);
+      this.updateCurrentSnapshot(svgMouseX);
+    }
   }
 
   leftEnvironment(event: MouseEvent): void {
-    this.hideTooltip();
-    this.currentSnapshot = undefined;
+    if (!this.clickOn) {
+      this.hideTooltip();
+      this.currentSnapshot = undefined;
+    }
   }
 
   hideTooltip(): void {
@@ -268,5 +278,9 @@ export class EnvironmentComponent implements OnInit, OnChanges {
       0,
       this.svgWidth
     );
+  }
+
+  updateClickOn(): void {
+    this.clickOn = !this.clickOn;
   }
 }

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -191,8 +191,10 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   enteredEnvironment(event: MouseEvent): void {
-    this.tooltip.envName = this.environment.name;
-    this.moveTooltip(event);
+    if (!this.tooltip.clickOn) {
+      this.tooltip.envName = this.environment.name;
+      this.moveTooltip(event);
+    }
   }
 
   moveTooltip(event: MouseEvent): void {
@@ -210,8 +212,6 @@ export class EnvironmentComponent implements OnInit, OnChanges {
     }
   }
 
-  // TODO(ancar): Make it work for when it leaves the environment, not
-  // it disappers only when you enter and then leave the tooltip.
   leftEnvironment(): void {
     if (!this.tooltip.clickOn) {
       this.hideTooltip();
@@ -297,15 +297,9 @@ export class EnvironmentComponent implements OnInit, OnChanges {
     this.tooltip.clickOn = !this.tooltip.clickOn;
   }
 
-  setTooltipHovered(value: boolean): void {
-    this.tooltipHovered = value;
-  }
-
   leaveDiv(): void {
-    if (!this.tooltipHovered) {
-      this.hideTooltip();
-      this.currentSnapshot = undefined;
-      this.tooltip.clickOn = false;
-    }
+    this.hideTooltip();
+    this.currentSnapshot = undefined;
+    this.tooltip.clickOn = false;
   }
 }

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -37,8 +37,6 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   currentSnapshot: Snapshot;
   currentCandidate: string;
 
-  tooltipHovered: boolean;
-
   constructor(
     private environmentService: EnvironmentService,
     private candidateService: CandidateService

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -205,6 +205,8 @@ export class EnvironmentComponent implements OnInit, OnChanges {
     }
   }
 
+  // TODO(ancar): Make it work for when it leaves the environment, not
+  // it disappers only when you enter and then leave the tooltip.
   leftEnvironment(event: MouseEvent): void {
     if (!this.tooltip.clickOn) {
       this.hideTooltip();

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -293,6 +293,8 @@ export class EnvironmentComponent implements OnInit, OnChanges {
     );
   }
 
+  /* if the clickOn property of the tooltip is true, the tooltip doesn't move anymore until either
+  clickOn becomes false or the mouse leaves the <div> of the environment */
   updateClickOn(): void {
     this.tooltip.clickOn = !this.tooltip.clickOn;
   }

--- a/step-release-vis/src/app/components/environment/environment_test.ts
+++ b/step-release-vis/src/app/components/environment/environment_test.ts
@@ -224,4 +224,73 @@ describe('EnvironmentComponent', () => {
       return fixture.debugElement.query(By.css('#cur-snapshot-line'));
     }
   });
+
+  describe('movement of the tooltip', () => {
+    beforeEach(() => {
+      component.environment.name = '1';
+    });
+
+    it('#enteredEnvironment', () => {
+      const svg = fixture.debugElement.query(By.css('svg'));
+      svg.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+
+      expect(component.tooltip.envName).toBe('1');
+    });
+
+    it('#moveTooltip with both cases of clickOn', () => {
+      const svg = fixture.debugElement.query(By.css('svg'));
+      svg.triggerEventHandler('mousemove', {pageX: 100, pageY: 100});
+      fixture.detectChanges();
+
+      expect(component.tooltip.mouseX).toEqual(100);
+      expect(component.tooltip.mouseY).toEqual(100);
+
+      svg.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      svg.triggerEventHandler('mousemove', {pageX: 110});
+      fixture.detectChanges();
+
+      // the position should be the same as clickOn is true
+      expect(component.tooltip.mouseX).toEqual(100);
+      expect(component.tooltip.mouseY).toEqual(100);
+    });
+
+    it('#leftEnvironment with both cases of clickOn', () => {
+      const svg = fixture.debugElement.query(By.css('svg'));
+      svg.triggerEventHandler('mouseleave', {});
+      fixture.detectChanges();
+
+      expect(component.tooltip.show).toBeFalse();
+
+      svg.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      svg.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      svg.triggerEventHandler('mouseleave', {});
+      fixture.detectChanges();
+
+      expect(component.tooltip.show).toBeTrue();
+    });
+  });
+
+  it('update ClickOn on click event', () => {
+    const svg = fixture.debugElement.query(By.css('svg'));
+    svg.triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    expect(component.tooltip.clickOn).toBeTrue();
+
+    svg.triggerEventHandler('click', {});
+    fixture.detectChanges();
+
+    expect(component.tooltip.clickOn).toBeFalse();
+  });
+
+  it('#hidetooltip', () => {
+    component.hideTooltip();
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('app-tooltip'))).toBeFalsy();
+  });
 });

--- a/step-release-vis/src/app/components/tooltip/tooltip.html
+++ b/step-release-vis/src/app/components/tooltip/tooltip.html
@@ -1,3 +1,5 @@
-<div class="tooltip" id="{{tooltip.envName}}">
-  <p *ngIf="isReady()"> {{getData()}} </p>
+<div class="tooltip" id="{{tooltip.envName}}"
+  (mouseenter)="enteredTooltip()"
+  (mouseleave)="leftTooltip()">
+  <p *ngIf="isReady()"> {{getData()}}</p>
 </div>

--- a/step-release-vis/src/app/components/tooltip/tooltip.html
+++ b/step-release-vis/src/app/components/tooltip/tooltip.html
@@ -1,5 +1,5 @@
 <div class="tooltip" id="{{tooltip.envName}}"
      (mouseenter)="enteredTooltip()"
-     (mouseleave)="leftTooltip()">
-  <p *ngIf="isReady()"> {{getData()}}</p>
+     (mouseleave)="leftTooltip()"
+     [innerHTML]="getData()">
 </div>

--- a/step-release-vis/src/app/components/tooltip/tooltip.html
+++ b/step-release-vis/src/app/components/tooltip/tooltip.html
@@ -1,7 +1,5 @@
 <div class="tooltip" id="{{tooltip.envName}}"
      *ngIf="isReady()"
      [ngStyle]="{'font-size':fontMultiplier+'vw'}"
-     [innerHTML]="getData()"
-     (mouseenter)="enteredTooltip()"
-     (mouseleave)="leftTooltip()">
+     [innerHTML]="getData()">
 </div>

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -10,7 +10,7 @@ import {Tooltip} from '../../models/Tooltip';
 export class TooltipComponent implements OnInit {
   @Input() tooltip: Tooltip;
   @Input() currentSnapshot: Snapshot;
-  @Output() tooltipHovered = new EventEmitter<boolean>();
+  @Output() tooltipHovered: EventEmitter<boolean> = new EventEmitter();
   @Input() currentCandidate: string;
 
   readonly PIXELS_PER_CAND = 20;

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -65,6 +65,17 @@ export class TooltipComponent implements OnInit {
     return this.height + 'px';
   }
 
+  enteredTooltip(): void {
+    if (this.tooltip.clickOn) {
+      this.tooltip.hoveredOver = true;
+    }
+  }
+
+  leftTooltip(): void {
+    this.tooltip.hoveredOver = false;
+    this.tooltip.clickOn = false;
+  }
+
   private updateStyle(): void {
     const tooltipElement = document.getElementById(this.tooltip.envName);
     if (tooltipElement) {

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, Output, EventEmitter} from '@angular/core';
 import {Snapshot} from '../../models/Data';
 import {Tooltip} from '../../models/Tooltip';
 
@@ -10,6 +10,7 @@ import {Tooltip} from '../../models/Tooltip';
 export class TooltipComponent implements OnInit {
   @Input() tooltip: Tooltip;
   @Input() currentSnapshot: Snapshot;
+  @Output() tooltipHovered = new EventEmitter<boolean>();
   width = 200;
   height = 50;
 
@@ -66,13 +67,11 @@ export class TooltipComponent implements OnInit {
   }
 
   enteredTooltip(): void {
-    if (this.tooltip.clickOn) {
-      this.tooltip.hoveredOver = true;
-    }
+    this.tooltipHovered.emit(true);
   }
 
   leftTooltip(): void {
-    this.tooltip.hoveredOver = false;
+    this.tooltipHovered.emit(false);
     this.tooltip.clickOn = false;
   }
 

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -92,15 +92,6 @@ export class TooltipComponent implements OnInit {
     );
   }
 
-  enteredTooltip(): void {
-    this.tooltipHovered.emit(true);
-  }
-
-  leftTooltip(): void {
-    this.tooltipHovered.emit(false);
-    this.tooltip.clickOn = false;
-  }
-
   private updateStyle(): void {
     const tooltipElement = document.getElementById(this.tooltip.envName);
     if (tooltipElement) {

--- a/step-release-vis/src/app/models/Tooltip.ts
+++ b/step-release-vis/src/app/models/Tooltip.ts
@@ -7,6 +7,8 @@
 export class Tooltip {
   mouseX: number;
   mouseY: number;
+  clickOn: boolean;
+  hoveredOver: boolean;
 
   show = false;
 

--- a/step-release-vis/src/app/models/Tooltip.ts
+++ b/step-release-vis/src/app/models/Tooltip.ts
@@ -8,7 +8,6 @@ export class Tooltip {
   mouseX: number;
   mouseY: number;
   clickOn: boolean;
-  hoveredOver: boolean;
 
   show = false;
 


### PR DESCRIPTION
At the moment with these changes when you first click on the current position of an environment the tooltip doesn't move anymore so the user can click the rapid links inside the tooltip.
When you click again the tooltip over that environment comes back to its normal behaviour.
Right now you can have multiple tooltips shown if there were some click actions over several environments. Should there be only one shown at the time if it was clicked?

In this screenshot the tooltips shown are fixed because there was a click actions on their environments:
![Screenshot 2020-09-03 at 9 51 03 AM - Display 1](https://user-images.githubusercontent.com/44673324/92081000-184c0280-edcb-11ea-9596-a3fbd67695b4.png)
