### PR TITLE
Save chosen time range to sessionStorage.

### DIFF
--- a/step-release-vis/src/app/components/environments/environments.ts
+++ b/step-release-vis/src/app/components/environments/environments.ts
@@ -18,6 +18,8 @@ export class EnvironmentsComponent implements OnInit {
   readonly TIMELINE_POINT_WIDTH = 130;
   readonly WEEK_SECONDS = 7 * 24 * 60 * 60;
   readonly TZ_OFFSET = new Date().getTimezoneOffset() * 60;
+  readonly START_TIMESTAMP_KEY = 'start_timestamp';
+  readonly END_TIMESTAMP_KEY = 'end_timestamp';
 
   environments: Environment[];
   envWidth: number;
@@ -95,9 +97,22 @@ export class EnvironmentsComponent implements OnInit {
     this.minTimestamp = minTimestamp;
     this.maxTimestamp = maxTimestamp;
 
-    this.startTimestamp = this.maxTimestamp - this.WEEK_SECONDS;
-    this.endTimestamp = this.maxTimestamp;
+    this.setStartEndTimestamps();
     this.onTimeRangeUpdate();
+  }
+
+  private setStartEndTimestamps(): void {
+    const localStartTimestamp = this.getStartTimestampFromStorage();
+    const localEndTimestamp = this.getEndTimestampFromStorage();
+    if (localStartTimestamp && localEndTimestamp) {
+      this.startTimestamp = parseInt(localStartTimestamp, 10);
+      this.endTimestamp = parseInt(localEndTimestamp, 10);
+    } else {
+      this.startTimestamp = this.maxTimestamp - this.WEEK_SECONDS;
+      this.endTimestamp = this.maxTimestamp;
+      this.saveStartTimestampToStorage();
+      this.saveEndTimestampToStorage();
+    }
   }
 
   /**
@@ -190,12 +205,30 @@ export class EnvironmentsComponent implements OnInit {
 
   onEndTimestampChange(event: Event): void {
     this.endTimestamp = this.getTimestampFromEvent(event);
+    this.saveEndTimestampToStorage();
     this.onTimeRangeUpdate();
   }
 
   onStartTimestampChange(event: Event): void {
     this.startTimestamp = this.getTimestampFromEvent(event);
+    this.saveStartTimestampToStorage();
     this.onTimeRangeUpdate();
+  }
+
+  getStartTimestampFromStorage(): string {
+    return sessionStorage.getItem(this.START_TIMESTAMP_KEY);
+  }
+
+  saveStartTimestampToStorage(): void {
+    sessionStorage.setItem(this.START_TIMESTAMP_KEY, `${this.startTimestamp}`);
+  }
+
+  getEndTimestampFromStorage(): string {
+    return sessionStorage.getItem(this.END_TIMESTAMP_KEY);
+  }
+
+  saveEndTimestampToStorage(): void {
+    sessionStorage.setItem(this.END_TIMESTAMP_KEY, `${this.endTimestamp}`);
   }
 
   /**

--- a/step-release-vis/src/app/components/environments/environments_test.ts
+++ b/step-release-vis/src/app/components/environments/environments_test.ts
@@ -51,6 +51,11 @@ describe('EnvironmentsComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    sessionStorage.removeItem(component.START_TIMESTAMP_KEY);
+    sessionStorage.removeItem(component.END_TIMESTAMP_KEY);
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -66,6 +71,28 @@ describe('EnvironmentsComponent', () => {
 
   it('should calculate timelinePoints', () => {
     expect(component.timelinePoints).toBeTruthy();
+  });
+
+  describe('start/end fields', () => {
+    it('should assign start/end fields', () => {
+      expect(component.startTimestamp).toBeTruthy();
+      expect(component.endTimestamp).toBeTruthy();
+    });
+
+    it('should read start/end from sessionStorage', () => {
+      sessionStorage.setItem(
+        component.START_TIMESTAMP_KEY,
+        `${component.minTimestamp}`
+      );
+      sessionStorage.setItem(
+        component.END_TIMESTAMP_KEY,
+        `${component.maxTimestamp}`
+      );
+      component.ngOnInit();
+      fixture.detectChanges();
+      expect(component.startTimestamp).toEqual(component.minTimestamp);
+      expect(component.endTimestamp).toEqual(component.maxTimestamp);
+    });
   });
 
   it('should generate timelinePoints which fit timeline and bounds', () => {
@@ -174,8 +201,7 @@ describe('EnvironmentsComponent', () => {
     });
   });
 
-  describe('timerange update', () => {
-    const tzOffset = new Date().getTimezoneOffset() * 60;
+  describe('time range update', () => {
     it('should update start/end timestamps on event triggers', () => {
       const startInput = fixture.debugElement.query(
         By.css('#timerange-start-input')
@@ -183,16 +209,35 @@ describe('EnvironmentsComponent', () => {
       const endInput = fixture.debugElement.query(
         By.css('#timerange-end-input')
       );
-      const oldStart = component.startTimestamp;
-      const oldEnd = component.endTimestamp;
-      startInput.triggerEventHandler('input', event(oldStart + 1000));
-      endInput.triggerEventHandler('input', event(oldEnd - 1000));
-      expect(component.startTimestamp).toEqual(oldStart + 1000);
-      expect(component.endTimestamp).toEqual(oldEnd - 1000);
+      const newStart = component.startTimestamp + 1000;
+      const newEnd = component.endTimestamp - 1000;
+      startInput.triggerEventHandler('input', event(newStart));
+      endInput.triggerEventHandler('input', event(newEnd));
+      expect(component.startTimestamp).toEqual(newStart);
+      expect(component.endTimestamp).toEqual(newEnd);
       component.timelinePoints.forEach(({timestamp}) => {
         expect(timestamp).toBeGreaterThanOrEqual(component.startTimestamp);
         expect(timestamp).toBeLessThanOrEqual(component.endTimestamp);
       });
+    });
+
+    it('should save start/end timestamps to storage', () => {
+      const startInput = fixture.debugElement.query(
+        By.css('#timerange-start-input')
+      );
+      const endInput = fixture.debugElement.query(
+        By.css('#timerange-end-input')
+      );
+      const newStart = component.startTimestamp + 1000;
+      const newEnd = component.endTimestamp - 1000;
+      startInput.triggerEventHandler('input', event(newStart));
+      endInput.triggerEventHandler('input', event(newEnd));
+      expect(sessionStorage.getItem(component.START_TIMESTAMP_KEY)).toEqual(
+        `${newStart}`
+      );
+      expect(sessionStorage.getItem(component.END_TIMESTAMP_KEY)).toEqual(
+        `${newEnd}`
+      );
     });
   });
 


### PR DESCRIPTION
* The chosen time range is saved to sessionStorage
* If the sessionStorage has relevant data, it is used. Otherwise start/end are set to _last-week/last_
* sessionStorage is local for each tab. It survives page reload, but not close and open tab