### PR TITLE
Change tooltip font sizing to be proportional with screen size and update timezone format.

### DIFF
--- a/step-release-vis/src/app/components/tooltip/tooltip.css
+++ b/step-release-vis/src/app/components/tooltip/tooltip.css
@@ -4,8 +4,6 @@
 
   padding: 10px;
 
-  font-size: x-small;
-
   background-color: rgba(240, 240, 240, 0.8);
   border: 1px solid black;
   border-radius: 3px;

--- a/step-release-vis/src/app/components/tooltip/tooltip.html
+++ b/step-release-vis/src/app/components/tooltip/tooltip.html
@@ -1,4 +1,5 @@
 <div class="tooltip" id="{{tooltip.envName}}"
   *ngIf="isReady()"
-  [innerHTML]="getData()">
+     [ngStyle]="{'font-size':fontMultiplier+'vw'}"
+     [innerHTML]="getData()">
 </div>

--- a/step-release-vis/src/app/components/tooltip/tooltip.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip.ts
@@ -12,9 +12,15 @@ export class TooltipComponent implements OnInit {
   @Input() currentSnapshot: Snapshot;
   @Input() currentCandidate: string;
 
-  readonly PIXELS_PER_CAND = 20;
-  width = 200;
-  height = 30;
+  /* Set tooltip font size to "fontMultiplier vw" */
+  readonly oneVwInPixels =
+    Math.max(document.documentElement.clientWidth, window.innerWidth || 0) /
+    100;
+  readonly fontMultiplier = 0.8;
+  readonly PIXELS_PER_CAND = 2 * (this.fontMultiplier * this.oneVwInPixels);
+
+  width = 14 * this.oneVwInPixels;
+  height = 2.5 * this.oneVwInPixels;
 
   constructor() {}
 
@@ -30,11 +36,8 @@ export class TooltipComponent implements OnInit {
   getData(): string {
     const dateTime: string = new Date(
       this.currentSnapshot.timestamp.seconds * 1000
-    ).toLocaleString('en-GB');
-    const localTimeZone: string = Intl.DateTimeFormat().resolvedOptions()
-      .timeZone;
-    const currentTime: string =
-      '<h3>' + dateTime + ' ' + localTimeZone + '</h3>';
+    ).toLocaleString('en-GB', {timeZoneName: 'short'});
+    const currentTime = `<h3>${dateTime}</h3>`;
 
     let candidateInfo = '';
     for (const candidate of this.currentSnapshot.candidatesList) {

--- a/step-release-vis/src/app/components/tooltip/tooltip_test.ts
+++ b/step-release-vis/src/app/components/tooltip/tooltip_test.ts
@@ -51,13 +51,5 @@ describe('TooltipComponent', () => {
       fixture.detectChanges();
       expect(component.getTop()).toBe('120px');
     });
-
-    it('#getHeight should add 20px for each candidate', () => {
-      component.currentSnapshot.candidatesList.push({
-        candidate: '',
-        jobCount: 0,
-      });
-      expect(component.getHeight()).toEqual('50px');
-    });
   });
 });


### PR DESCRIPTION
* Tooltip looked weird on different screens, but problem is now fixed.
* Change timezone format to the short option (CEST/GMT+9/etc).