### PR TITLE
Improve styling in non-expanded view.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.css
+++ b/step-release-vis/src/app/components/environment/environment.css
@@ -2,15 +2,21 @@
   font-family: Roboto, Arial, sans-serif;
 }
 
-.environment-container {
-  margin-top: 8px;
-}
-
 .environment-title {
   color: dimgrey;
   margin-bottom: 0;
   margin-top: 0;
   font-family: "Courier New", sans-serif;
+  display: inline-block;
+  vertical-align: top;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.expand-icon {
+  vertical-align: top;
+  display: inline
 }
 
 #cur-snapshot-line {

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -1,4 +1,8 @@
 <div class="environment-container">
+  <p
+    class="environment-title"
+    (click)="handleExpand()"
+  >{{environment.name}}</p>
   <!-- TODO(#248): display title and env in one line if not expanded -->
   <p
     class="environment-title"

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -1,73 +1,86 @@
-<div class="environment-container">
-  <p
-    class="environment-title"
-    (click)="handleExpand()"
-  >{{environment.name}}</p>
-  <!-- TODO(#248): display title and env in one line if not expanded -->
-  <p
-    class="environment-title"
-    (click)="handleExpand()"
-  >{{environment.name}}</p>
-  <div>
-    <app-tooltip
-        *ngIf="tooltip.show"
-        [tooltip]="tooltip"
-        [currentSnapshot]="currentSnapshot"
-        [currentCandidate]="currentCandidate"
+<app-tooltip
+  *ngIf="tooltip.show"
+  [tooltip]="tooltip"
+  [currentSnapshot]="currentSnapshot"
+  [currentCandidate]="currentCandidate"
+>
+</app-tooltip>
+<div class="environment-container"
+     [ngStyle]="{'padding-bottom': getEnvPaddingBottom()}"
+>
+  <div class="title"
+       [ngStyle]="{display: getTitleDisplay()}"
+       (click)="handleExpand()"
+  >
+    <svg
+      class="expand-icon"
+      [attr.width]="TITLE_ICON_SIZE + 'px'"
+      [attr.height]="TITLE_ICON_SIZE + 'px'"
     >
-    </app-tooltip>
-    <svg id="{{environment.name}}-svg" xmlns="http://www.w3.org/2000/svg" [attr.width]="svgWidth" [attr.height]="svgHeight"
-         (mouseenter)="enteredEnvironment($event)"
-         (mouseleave)="leftEnvironment($event)"
-         (mousemove)="moveTooltip($event)">
-      <polygon
-        *ngFor="let polygon of polygons"
-        [attr.points]="polygon.toAttributeString()"
-        [attr.fill]="getColor(polygon)"
-        [attr.fill-opacity]="getOpacity(polygon)"
-        (mouseenter)="enteredPolygon(polygon)"
-        (mouseleave)="leftPolygon(polygon)"
-      >
-      </polygon>
-      <rect
-        *ngIf="currentSnapshot"
-        id="cur-snapshot-line"
-        [attr.x]="getLineX() - 1"
-        [attr.y]="0"
-        [attr.width]="2"
-        [attr.height]="expanded ? svgHeight - TIMELINE_HEIGHT + 10 : svgHeight"
-        fill="white"
-      />
-      <g id="timeline" *ngIf="expanded">
-        <rect [attr.x]="0" [attr.y]="svgHeight - TIMELINE_HEIGHT + 10" [attr.width]="svgWidth" [attr.height]="2"
-              fill="gray"/>
-        <text
-          *ngFor="let timelinePoint of timelinePoints; let i = index"
-          [attr.x]="timelinePoint.x"
-          [attr.y]="svgHeight - 12"
-          [attr.text-anchor]="getTimelinePointTextAlignment(i)"
-          font-size="12"
-        >
-          {{ timelinePoint.timeString }}
-        </text>
-        <text
-          *ngFor="let timelinePoint of timelinePoints; let i = index"
-          [attr.x]="timelinePoint.x"
-          [attr.y]="svgHeight"
-          [attr.text-anchor]="getTimelinePointTextAlignment(i)"
-          font-size="12"
-        >
-          {{ timelinePoint.dateString }}
-        </text>
-        <line
-          *ngFor="let timelinePoint of timelinePoints"
-          [attr.x1]="timelinePoint.x"
-          [attr.y1]="svgHeight - TIMELINE_HEIGHT + 2"
-          [attr.x2]="timelinePoint.x"
-          [attr.y2]="svgHeight - TIMELINE_HEIGHT / 2 - 3"
-          stroke="gray"
-        />
+      <g [attr.transform]="expanded ? 'translate(0, 5)' : 'translate(0, 4)'">
+        <polygon [attr.points]="expanded ? '0,0 10,0 5,8.66' : '0,0 8.66,5 0,10'" fill="dimgrey"/>
       </g>
     </svg>
+    <p
+      class="environment-title"
+      [ngStyle]="{width: getTitleNameWidth(),'margin-right': TITLE_MARGIN + 'px'}"
+    >{{environment.name}}</p>
   </div>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    id="{{environment.name}}-svg"
+    [attr.width]="svgWidth"
+    [attr.height]="svgHeight"
+    (mouseenter)="enteredEnvironment($event)"
+    (mouseleave)="leftEnvironment($event)"
+    (mousemove)="moveTooltip($event)">
+    <polygon
+      class="cand-polygon"
+      *ngFor="let polygon of polygons"
+      [attr.points]="polygon.toAttributeString()"
+      [attr.fill]="getColor(polygon)"
+      [attr.fill-opacity]="getOpacity(polygon)"
+      (mouseenter)="enteredPolygon(polygon)"
+      (mouseleave)="leftPolygon(polygon)"
+    />
+    <rect
+      *ngIf="currentSnapshot"
+      id="cur-snapshot-line"
+      [attr.x]="getLineX() - 1"
+      [attr.y]="0"
+      [attr.width]="2"
+      [attr.height]="expanded ? svgHeight - TIMELINE_HEIGHT + 10 : svgHeight"
+      fill="white"
+    />
+    <g id="timeline" *ngIf="expanded">
+      <rect [attr.x]="0" [attr.y]="svgHeight - TIMELINE_HEIGHT + 10" [attr.width]="svgWidth" [attr.height]="2"
+            fill="gray"/>
+      <text
+        *ngFor="let timelinePoint of timelinePoints; let i = index"
+        [attr.x]="timelinePoint.x"
+        [attr.y]="svgHeight - 12"
+        [attr.text-anchor]="getTimelinePointTextAlignment(i)"
+        font-size="12"
+      >
+        {{ timelinePoint.timeString }}
+      </text>
+      <text
+        *ngFor="let timelinePoint of timelinePoints; let i = index"
+        [attr.x]="timelinePoint.x"
+        [attr.y]="svgHeight"
+        [attr.text-anchor]="getTimelinePointTextAlignment(i)"
+        font-size="12"
+      >
+        {{ timelinePoint.dateString }}
+      </text>
+      <line
+        *ngFor="let timelinePoint of timelinePoints"
+        [attr.x1]="timelinePoint.x"
+        [attr.y1]="svgHeight - TIMELINE_HEIGHT + 2"
+        [attr.x2]="timelinePoint.x"
+        [attr.y2]="svgHeight - TIMELINE_HEIGHT / 2 - 3"
+        stroke="gray"
+      />
+    </g>
+  </svg>
 </div>

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -21,11 +21,14 @@ import {Tooltip} from '../../models/Tooltip';
 export class EnvironmentComponent implements OnInit, OnChanges {
   readonly TIMELINE_HEIGHT = 40;
   readonly SNAPSHOTS_PER_ENV = 500;
+  readonly TITLE_MARGIN = 10;
+  readonly TITLE_ICON_SIZE = 20;
 
   @Input() svgSmallWidth: number;
   @Input() svgSmallHeight: number;
   @Input() svgBigWidth: number;
   @Input() svgBigHeight: number;
+  @Input() titleWidth;
 
   svgWidth: number;
   svgHeight: number;
@@ -301,5 +304,19 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   private updateDimensions(): void {
     this.svgWidth = this.expanded ? this.svgBigWidth : this.svgSmallWidth;
     this.svgHeight = this.expanded ? this.svgBigHeight : this.svgSmallHeight;
+  }
+
+  getTitleDisplay(): string {
+    return this.expanded ? 'block' : 'inline';
+  }
+
+  getTitleNameWidth(): string {
+    return this.expanded
+      ? 'auto'
+      : `${this.titleWidth - this.TITLE_MARGIN - this.TITLE_ICON_SIZE}px`;
+  }
+
+  getEnvPaddingBottom(): string {
+    return this.expanded ? '15px' : '0px';
   }
 }

--- a/step-release-vis/src/app/components/environment/environment_test.ts
+++ b/step-release-vis/src/app/components/environment/environment_test.ts
@@ -65,7 +65,7 @@ describe('EnvironmentComponent', () => {
     });
 
     it('should respond to hover events', () => {
-      const polygons = fixture.debugElement.queryAll(By.css('polygon'));
+      const polygons = fixture.debugElement.queryAll(By.css('.cand-polygon'));
       for (let i = 0; i < polygons.length; i++) {
         polygons[i].triggerEventHandler('mouseenter', {});
         fixture.detectChanges();
@@ -234,14 +234,14 @@ describe('EnvironmentComponent', () => {
       expect(component.svgHeight).toEqual(component.svgSmallHeight);
 
       fixture.debugElement
-        .query(By.css('.environment-title'))
+        .query(By.css('.title'))
         .triggerEventHandler('click', {});
       expect(component.expanded).toBeTrue();
       expect(component.svgWidth).toEqual(component.svgBigWidth);
       expect(component.svgHeight).toEqual(component.svgBigHeight);
 
       fixture.debugElement
-        .query(By.css('.environment-title'))
+        .query(By.css('.title'))
         .triggerEventHandler('click', {});
       expect(component.expanded).toBeFalse();
       expect(component.svgWidth).toEqual(component.svgSmallWidth);
@@ -251,13 +251,13 @@ describe('EnvironmentComponent', () => {
     it('should hide/unhide the timeline', () => {
       expect(fixture.debugElement.query(By.css('#timeline'))).toBeFalsy();
       fixture.debugElement
-        .query(By.css('.environment-title'))
+        .query(By.css('.title'))
         .triggerEventHandler('click', {});
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#timeline'))).toBeTruthy();
 
       fixture.debugElement
-        .query(By.css('.environment-title'))
+        .query(By.css('.title'))
         .triggerEventHandler('click', {});
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css('#timeline'))).toBeFalsy();

--- a/step-release-vis/src/app/components/environments/environments.html
+++ b/step-release-vis/src/app/components/environments/environments.html
@@ -29,6 +29,7 @@
     [startTimestamp]="startTimestamp"
     [endTimestamp]="endTimestamp"
     [timelinePoints]="timelinePoints"
+    [titleWidth]="TITLE_WIDTH"
   >
   </app-environment>
 </div>

--- a/step-release-vis/src/app/components/environments/environments.ts
+++ b/step-release-vis/src/app/components/environments/environments.ts
@@ -14,8 +14,9 @@ import {Observable} from 'rxjs';
 })
 export class EnvironmentsComponent implements OnInit {
   readonly ENVS_PER_PAGE = 30;
-  readonly ENVS_PER_PAGE_EXPANDED = 5;
-  readonly ENV_RIGHT_MARGIN = 100;
+  readonly ENVS_PER_PAGE_EXPANDED = 7;
+  readonly ENV_RIGHT_MARGIN = 20;
+  readonly TITLE_WIDTH = 280;
   readonly TIMELINE_POINT_WIDTH = 130;
   readonly WEEK_SECONDS = 7 * 24 * 60 * 60;
   readonly TZ_OFFSET = new Date().getTimezoneOffset() * 60;
@@ -83,7 +84,8 @@ export class EnvironmentsComponent implements OnInit {
    * @param environments an array of environments
    */
   private processEnvironments(environments: Environment[]): void {
-    this.envSmallWidth = window.innerWidth - this.ENV_RIGHT_MARGIN;
+    this.envSmallWidth =
+      window.innerWidth - this.ENV_RIGHT_MARGIN - this.TITLE_WIDTH;
     this.envSmallHeight = window.innerHeight / this.ENVS_PER_PAGE;
     this.envBigWidth = window.innerWidth - this.ENV_RIGHT_MARGIN;
     this.envBigHeight = window.innerHeight / this.ENVS_PER_PAGE_EXPANDED;

--- a/step-release-vis/src/app/components/environments/environments_test.ts
+++ b/step-release-vis/src/app/components/environments/environments_test.ts
@@ -100,7 +100,7 @@ describe('EnvironmentsComponent', () => {
       expect(timestamp).toBeGreaterThanOrEqual(component.startTimestamp);
       expect(timestamp).toBeLessThanOrEqual(component.endTimestamp);
       expect(x).toBeGreaterThanOrEqual(0);
-      expect(x).toBeLessThanOrEqual(component.envSmallWidth);
+      expect(x).toBeLessThanOrEqual(component.envBigWidth);
     });
   });
   it('should have first and last timeline points close to edges', () => {


### PR DESCRIPTION
* Display the title and the env on one line if the view is non-expanded
* Add an expansion triangle  icon

Non-expanded:
![image](https://user-images.githubusercontent.com/35143083/92135968-22deba00-ee14-11ea-8806-acc1b739a61e.png)

Expanded:
![image](https://user-images.githubusercontent.com/35143083/92136043-38ec7a80-ee14-11ea-9b72-0ddcccd781ca.png)
