### PR TITLE
Improve out of view envs handling.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.css
+++ b/step-release-vis/src/app/components/environment/environment.css
@@ -19,6 +19,10 @@
   display: inline
 }
 
+#no-data {
+  font-size: 12px;
+}
+
 #cur-snapshot-line {
   pointer-events: none;
   mix-blend-mode: difference;

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -29,6 +29,19 @@
        (mouseenter)="enteredEnvironment($event)"
        (mouseleave)="leftEnvironment($event)"
        (mousemove)="moveTooltip($event)">
+    <line [attr.x1]="0"
+          [attr.y1]="0"
+          [attr.x2]="svgWidth"
+          [attr.y2]="0"
+          stroke="gray"
+    />
+    <line *ngIf="!expanded"
+          [attr.x1]="0"
+          [attr.y1]="svgHeight"
+          [attr.x2]="svgWidth"
+          [attr.y2]="svgHeight"
+          stroke="gray"
+    />
     <polygon class="cand-polygon"
              *ngFor="let polygon of polygons"
              [attr.points]="polygon.toAttributeString()"
@@ -47,7 +60,8 @@
           *ngIf="displayedSnapshots.length === 0"
           [attr.x]="svgWidth / 2"
           [attr.y]="svgHeight / 2"
-          text-anchor="middle">
+          text-anchor="middle"
+          alignment-baseline="middle">
       No data for this period
     </text>
     <g id="timeline" *ngIf="expanded">

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -52,6 +52,13 @@
       [attr.height]="expanded ? svgHeight - TIMELINE_HEIGHT + 10 : svgHeight"
       fill="white"
     />
+    <text
+      *ngIf="displayedSnapshots.length === 0"
+      [attr.x]="svgWidth / 2"
+      [attr.y]="svgHeight / 2"
+      text-anchor="middle"
+    >No data for this period
+    </text>
     <g id="timeline" *ngIf="expanded">
       <rect [attr.x]="0" [attr.y]="svgHeight - TIMELINE_HEIGHT + 10" [attr.width]="svgWidth" [attr.height]="2"
             fill="gray"/>
@@ -61,9 +68,7 @@
         [attr.y]="svgHeight - 12"
         [attr.text-anchor]="getTimelinePointTextAlignment(i)"
         font-size="12"
-      >
-        {{ timelinePoint.timeString }}
-      </text>
+      >{{ timelinePoint.timeString }}</text>
       <text
         *ngFor="let timelinePoint of timelinePoints; let i = index"
         [attr.x]="timelinePoint.x"

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -43,7 +43,8 @@
           [attr.width]="2"
           [attr.height]="expanded ? svgHeight - TIMELINE_HEIGHT + 10 : svgHeight"
           fill="white"/>
-    <text *ngIf="displayedSnapshots.length === 0"
+    <text id="no-data"
+          *ngIf="displayedSnapshots.length === 0"
           [attr.x]="svgWidth / 2"
           [attr.y]="svgHeight / 2"
           text-anchor="middle">

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -6,86 +6,74 @@
 >
 </app-tooltip>
 <div class="environment-container"
-     [ngStyle]="{'padding-bottom': getEnvPaddingBottom()}"
->
+     [ngStyle]="{'padding-bottom': getEnvPaddingBottom()}">
   <div class="title"
        [ngStyle]="{display: getTitleDisplay()}"
-       (click)="handleExpand()"
-  >
-    <svg
-      class="expand-icon"
-      [attr.width]="TITLE_ICON_SIZE + 'px'"
-      [attr.height]="TITLE_ICON_SIZE + 'px'"
-    >
+       (click)="handleExpand()">
+    <svg class="expand-icon"
+         [attr.width]="TITLE_ICON_SIZE + 'px'"
+         [attr.height]="TITLE_ICON_SIZE + 'px'">
       <g [attr.transform]="expanded ? 'translate(0, 5)' : 'translate(0, 4)'">
         <polygon [attr.points]="expanded ? '0,0 10,0 5,8.66' : '0,0 8.66,5 0,10'" fill="dimgrey"/>
       </g>
     </svg>
-    <p
-      class="environment-title"
-      [ngStyle]="{width: getTitleNameWidth(),'margin-right': TITLE_MARGIN + 'px'}"
-    >{{environment.name}}</p>
+    <p class="environment-title"
+       [ngStyle]="{width: getTitleNameWidth(),'margin-right': TITLE_MARGIN + 'px'}">
+      {{environment.name}}
+    </p>
   </div>
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    id="{{environment.name}}-svg"
-    [attr.width]="svgWidth"
-    [attr.height]="svgHeight"
-    (mouseenter)="enteredEnvironment($event)"
-    (mouseleave)="leftEnvironment($event)"
-    (mousemove)="moveTooltip($event)">
-    <polygon
-      class="cand-polygon"
-      *ngFor="let polygon of polygons"
-      [attr.points]="polygon.toAttributeString()"
-      [attr.fill]="getColor(polygon)"
-      [attr.fill-opacity]="getOpacity(polygon)"
-      (mouseenter)="enteredPolygon(polygon)"
-      (mouseleave)="leftPolygon(polygon)"
-    />
-    <rect
-      *ngIf="shouldDisplayLine()"
-      id="cur-snapshot-line"
-      [attr.x]="getLineX() - 1"
-      [attr.y]="0"
-      [attr.width]="2"
-      [attr.height]="expanded ? svgHeight - TIMELINE_HEIGHT + 10 : svgHeight"
-      fill="white"
-    />
-    <text
-      *ngIf="displayedSnapshots.length === 0"
-      [attr.x]="svgWidth / 2"
-      [attr.y]="svgHeight / 2"
-      text-anchor="middle"
-    >No data for this period
+  <svg xmlns="http://www.w3.org/2000/svg"
+       id="{{environment.name}}-svg"
+       [attr.width]="svgWidth"
+       [attr.height]="svgHeight"
+       (mouseenter)="enteredEnvironment($event)"
+       (mouseleave)="leftEnvironment($event)"
+       (mousemove)="moveTooltip($event)">
+    <polygon class="cand-polygon"
+             *ngFor="let polygon of polygons"
+             [attr.points]="polygon.toAttributeString()"
+             [attr.fill]="getColor(polygon)"
+             [attr.fill-opacity]="getOpacity(polygon)"
+             (mouseenter)="enteredPolygon(polygon)"
+             (mouseleave)="leftPolygon(polygon)"/>
+    <rect *ngIf="shouldDisplayLine()"
+          id="cur-snapshot-line"
+          [attr.x]="getLineX() - 1"
+          [attr.y]="0"
+          [attr.width]="2"
+          [attr.height]="expanded ? svgHeight - TIMELINE_HEIGHT + 10 : svgHeight"
+          fill="white"/>
+    <text *ngIf="displayedSnapshots.length === 0"
+          [attr.x]="svgWidth / 2"
+          [attr.y]="svgHeight / 2"
+          text-anchor="middle">
+      No data for this period
     </text>
     <g id="timeline" *ngIf="expanded">
-      <rect [attr.x]="0" [attr.y]="svgHeight - TIMELINE_HEIGHT + 10" [attr.width]="svgWidth" [attr.height]="2"
+      <rect [attr.x]="0"
+            [attr.y]="svgHeight - TIMELINE_HEIGHT + 10"
+            [attr.width]="svgWidth" [attr.height]="2"
             fill="gray"/>
-      <text
-        *ngFor="let timelinePoint of timelinePoints; let i = index"
-        [attr.x]="timelinePoint.x"
-        [attr.y]="svgHeight - 12"
-        [attr.text-anchor]="getTimelinePointTextAlignment(i)"
-        font-size="12"
-      >{{ timelinePoint.timeString }}</text>
-      <text
-        *ngFor="let timelinePoint of timelinePoints; let i = index"
-        [attr.x]="timelinePoint.x"
-        [attr.y]="svgHeight"
-        [attr.text-anchor]="getTimelinePointTextAlignment(i)"
-        font-size="12"
-      >
+      <text *ngFor="let timelinePoint of timelinePoints; let i = index"
+            [attr.x]="timelinePoint.x"
+            [attr.y]="svgHeight - 12"
+            [attr.text-anchor]="getTimelinePointTextAlignment(i)"
+            font-size="12">
+        {{ timelinePoint.timeString }}
+      </text>
+      <text *ngFor="let timelinePoint of timelinePoints; let i = index"
+            [attr.x]="timelinePoint.x"
+            [attr.y]="svgHeight"
+            [attr.text-anchor]="getTimelinePointTextAlignment(i)"
+            font-size="12">
         {{ timelinePoint.dateString }}
       </text>
-      <line
-        *ngFor="let timelinePoint of timelinePoints"
-        [attr.x1]="timelinePoint.x"
-        [attr.y1]="svgHeight - TIMELINE_HEIGHT + 2"
-        [attr.x2]="timelinePoint.x"
-        [attr.y2]="svgHeight - TIMELINE_HEIGHT / 2 - 3"
-        stroke="gray"
-      />
+      <line *ngFor="let timelinePoint of timelinePoints"
+            [attr.x1]="timelinePoint.x"
+            [attr.y1]="svgHeight - TIMELINE_HEIGHT + 2"
+            [attr.x2]="timelinePoint.x"
+            [attr.y2]="svgHeight - TIMELINE_HEIGHT / 2 - 3"
+            stroke="gray"/>
     </g>
   </svg>
 </div>

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -61,7 +61,7 @@
           [attr.x]="svgWidth / 2"
           [attr.y]="svgHeight / 2"
           text-anchor="middle"
-          alignment-baseline="middle">
+          alignment-baseline="central">
       No data for this period
     </text>
     <g id="timeline" *ngIf="expanded">

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -251,6 +251,9 @@ export class EnvironmentComponent implements OnInit, OnChanges {
    * @param svgMouseX the position of the mouse relative to the svg
    */
   updateCurrentSnapshot(svgMouseX: number): void {
+    if (this.displayedSnapshots.length === 0) {
+      return;
+    }
     const firstDisplayedTimestampScaled = this.getPositionFromTimestamp(
       this.displayedSnapshots[0].timestamp.seconds
     );
@@ -322,7 +325,7 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   shouldDisplayLine(): boolean {
-    if (!this.curGlobalTimestamp) {
+    if (!this.curGlobalTimestamp || this.displayedSnapshots.length == 0) {
       return false;
     }
     return (

--- a/step-release-vis/src/app/components/environment/environment.ts
+++ b/step-release-vis/src/app/components/environment/environment.ts
@@ -325,7 +325,7 @@ export class EnvironmentComponent implements OnInit, OnChanges {
   }
 
   shouldDisplayLine(): boolean {
-    if (!this.curGlobalTimestamp || this.displayedSnapshots.length == 0) {
+    if (!this.curGlobalTimestamp || this.displayedSnapshots.length === 0) {
       return false;
     }
     return (


### PR DESCRIPTION
* Solve a bug causing errors when the env was completely out of view
* Add a label _No data for this period_ label, if the env is completely out of view
* Add lines on top and bottom of env to get rid of white void if many envs are out of view
* Refactor html

Compact:
![image](https://user-images.githubusercontent.com/35143083/92407644-d234cd00-f143-11ea-92b7-7fb7c4a5f078.png)

Expanded:
![image](https://user-images.githubusercontent.com/35143083/92407660-dd87f880-f143-11ea-9d5e-a830c41b933e.png)
