### PR TITLE
Make env height depend on screen height.

### DIFF
--- a/step-release-vis/src/app/components/environment/environment.css
+++ b/step-release-vis/src/app/components/environment/environment.css
@@ -2,7 +2,11 @@
   font-family: Roboto, Arial, sans-serif;
 }
 
-.environment-title {
+.title {
+  display: inline;
+}
+
+.title-name {
   color: dimgrey;
   margin-bottom: 0;
   margin-top: 0;
@@ -16,7 +20,11 @@
 
 .expand-icon {
   vertical-align: top;
-  display: inline
+  display: inline-block;
+}
+
+.env-svg {
+  vertical-align: top;
 }
 
 #no-data {

--- a/step-release-vis/src/app/components/environment/environment.html
+++ b/step-release-vis/src/app/components/environment/environment.html
@@ -1,42 +1,36 @@
 <div id="wrapper"
      (mouseleave)="leaveDiv()">
-  <app-tooltip
-    *ngIf="tooltip.show"
-    [tooltip]="tooltip"
-    [currentSnapshot]="currentSnapshot"
-    [currentCandidate]="currentCandidate"
-  >
+  <app-tooltip *ngIf="tooltip.show"
+               [tooltip]="tooltip"
+               [currentSnapshot]="currentSnapshot"
+               [currentCandidate]="currentCandidate">
   </app-tooltip>
   <div class="environment-container"
-       [ngStyle]="{'padding-bottom': getEnvPaddingBottom()}"
-  >
+       [ngStyle]="{'padding-bottom': getEnvPaddingBottom(), height: svgHeight + 'px'}">
     <div class="title"
-         [ngStyle]="{display: getTitleDisplay()}"
-         (click)="handleExpand()"
-    >
-      <svg
-        class="expand-icon"
-        [attr.width]="TITLE_ICON_SIZE + 'px'"
-        [attr.height]="TITLE_ICON_SIZE + 'px'"
-      >
-        <g [attr.transform]="expanded ? 'translate(0, 5)' : 'translate(0, 4)'">
-          <polygon [attr.points]="expanded ? '0,0 10,0 5,8.66' : '0,0 8.66,5 0,10'" fill="dimgrey"/>
+         (click)="handleExpand()">
+      <svg class="expand-icon"
+           [attr.width]="getTitleHeight()"
+           [attr.height]="getTitleHeight()">
+        <g>
+          <polygon [attr.points]="getExpandIcon()"
+                   fill="dimgrey"/>
         </g>
       </svg>
-      <p
-        class="environment-title"
-        [ngStyle]="{width: getTitleNameWidth(),'margin-right': TITLE_MARGIN + 'px'}"
-      >{{environment.name}}</p>
+      <p class="title-name"
+         [ngStyle]="{width: getTitleNameWidth(),'margin-right': TITLE_MARGIN + 'px', 'font-size': getTitleHeight()}">
+        {{environment.name}}
+      </p>
     </div>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      id="{{environment.name}}-svg"
-      [attr.width]="svgWidth"
-      [attr.height]="svgHeight"
-      (mouseenter)="enteredEnvironment($event)"
-      (mouseleave)="leftEnvironment()"
-      (mousemove)="moveTooltip($event)"
-      (click)="updateClickOn($event)">
+    <svg xmlns="http://www.w3.org/2000/svg"
+         class="env-svg"
+         id="{{environment.name}}-svg"
+         [attr.width]="svgWidth"
+         [attr.height]="svgHeight"
+         (mouseenter)="enteredEnvironment($event)"
+         (mouseleave)="leftEnvironment()"
+         (mousemove)="moveTooltip($event)"
+         (click)="updateClickOn($event)">
       <line [attr.x1]="0"
             [attr.y1]="0"
             [attr.x2]="svgWidth"
@@ -48,24 +42,20 @@
             [attr.x2]="svgWidth"
             [attr.y2]="svgHeight"
             stroke="gray"/>
-      <polygon
-        class="cand-polygon"
-        *ngFor="let polygon of polygons"
-        [attr.points]="polygon.toAttributeString()"
-        [attr.fill]="getColor(polygon)"
-        [attr.fill-opacity]="getOpacity(polygon)"
-        (mouseenter)="enteredPolygon(polygon)"
-        (mouseleave)="leftPolygon(polygon)"
-      />
-      <rect
-        *ngIf="shouldDisplayLine()"
-        id="cur-snapshot-line"
-        [attr.x]="getLineX() - 1"
-        [attr.y]="0"
-        [attr.width]="2"
-        [attr.height]="expanded ? svgHeight - TIMELINE_HEIGHT + 10 : svgHeight"
-        fill="white"
-      />
+      <polygon class="cand-polygon"
+               *ngFor="let polygon of polygons"
+               [attr.points]="polygon.toAttributeString()"
+               [attr.fill]="getColor(polygon)"
+               [attr.fill-opacity]="getOpacity(polygon)"
+               (mouseenter)="enteredPolygon(polygon)"
+               (mouseleave)="leftPolygon(polygon)"/>
+      <rect *ngIf="shouldDisplayLine()"
+            id="cur-snapshot-line"
+            [attr.x]="getLineX() - 1"
+            [attr.y]="0"
+            [attr.width]="2"
+            [attr.height]="expanded ? svgHeight - TIMELINE_HEIGHT + 10 : svgHeight"
+            fill="white"/>
       <text id="no-data"
             *ngIf="displayedSnapshots.length === 0"
             [attr.x]="svgWidth / 2"
@@ -73,24 +63,22 @@
         No data for this period
       </text>
       <g id="timeline" *ngIf="expanded">
-        <rect [attr.x]="0" [attr.y]="svgHeight - TIMELINE_HEIGHT + 10" [attr.width]="svgWidth" [attr.height]="2"
+        <rect [attr.x]="0"
+              [attr.y]="svgHeight - TIMELINE_HEIGHT + 10"
+              [attr.width]="svgWidth" [attr.height]="2"
               fill="gray"/>
-        <text
-          *ngFor="let timelinePoint of timelinePoints; let i = index"
-          [attr.x]="timelinePoint.x"
-          [attr.y]="svgHeight - 12"
-          [attr.text-anchor]="getTimelinePointTextAlignment(i)"
-          font-size="12"
-        >
+        <text *ngFor="let timelinePoint of timelinePoints; let i = index"
+              [attr.x]="timelinePoint.x"
+              [attr.y]="svgHeight - 12"
+              [attr.text-anchor]="getTimelinePointTextAlignment(i)"
+              font-size="12">
           {{ timelinePoint.timeString }}
         </text>
-        <text
-          *ngFor="let timelinePoint of timelinePoints; let i = index"
-          [attr.x]="timelinePoint.x"
-          [attr.y]="svgHeight"
-          [attr.text-anchor]="getTimelinePointTextAlignment(i)"
-          font-size="12"
-        >
+        <text *ngFor="let timelinePoint of timelinePoints; let i = index"
+              [attr.x]="timelinePoint.x"
+              [attr.y]="svgHeight"
+              [attr.text-anchor]="getTimelinePointTextAlignment(i)"
+              font-size="12">
           {{ timelinePoint.dateString }}
         </text>
         <line
@@ -99,8 +87,7 @@
           [attr.y1]="svgHeight - TIMELINE_HEIGHT + 2"
           [attr.x2]="timelinePoint.x"
           [attr.y2]="svgHeight - TIMELINE_HEIGHT / 2 - 3"
-          stroke="gray"
-        />
+          stroke="gray"/>
       </g>
     </svg>
   </div>

--- a/step-release-vis/src/app/components/environment/environment_test.ts
+++ b/step-release-vis/src/app/components/environment/environment_test.ts
@@ -358,17 +358,21 @@ describe('EnvironmentComponent', () => {
     expect(fixture.debugElement.query(By.css('app-tooltip'))).toBeFalsy();
   });
 
-  describe('time range update', () => {
+  describe('width update', () => {
     let oldWidth;
+    let oldHeight;
     beforeEach(() => {
       oldWidth = component.svgWidth;
+      oldHeight = component.svgSmallHeight;
       component.ngOnChanges({
         svgWidth: new SimpleChange(oldWidth, oldWidth - 100, false),
+        svgSmallHeight: new SimpleChange(oldHeight, oldHeight - 100, false),
       });
     });
 
     it('should update fields', () => {
       expect(component.svgWidth).toEqual(oldWidth - 100);
+      expect(component.svgSmallHeight).toEqual(oldHeight - 100);
     });
 
     it('should update snapshots', () => {

--- a/step-release-vis/src/app/components/environments/environments.html
+++ b/step-release-vis/src/app/components/environments/environments.html
@@ -30,6 +30,7 @@
     [timelinePoints]="timelinePoints"
     [titleWidth]="TITLE_WIDTH"
     [curGlobalTimestamp]="curGlobalTimestamp"
+    [envMarginBottom]="ENV_MARGIN_BOTTOM"
   >
   </app-environment>
 </div>

--- a/step-release-vis/src/app/components/environments/environments.ts
+++ b/step-release-vis/src/app/components/environments/environments.ts
@@ -13,8 +13,8 @@ import {Observable} from 'rxjs';
   styleUrls: ['./environments.css'],
 })
 export class EnvironmentsComponent implements OnInit {
-  readonly ENVS_PER_PAGE = 30;
-  readonly ENVS_PER_PAGE_EXPANDED = 7;
+  readonly ENV_MARGIN_BOTTOM = 7;
+  readonly ENV_EXPANDED_HEIGHT = 170;
   readonly ENV_RIGHT_MARGIN = 20;
   readonly TITLE_WIDTH = 280;
   readonly TIMELINE_POINT_WIDTH = 130;
@@ -136,8 +136,11 @@ export class EnvironmentsComponent implements OnInit {
 
   private updateDimensions(width: number, height: number): void {
     this.envWidth = width - this.ENV_RIGHT_MARGIN - this.TITLE_WIDTH;
-    this.envSmallHeight = height / this.ENVS_PER_PAGE;
-    this.envBigHeight = height / this.ENVS_PER_PAGE_EXPANDED;
+    this.envSmallHeight = Math.min(
+      (height - 50) / this.environments.length - this.ENV_MARGIN_BOTTOM,
+      50
+    );
+    this.envBigHeight = this.ENV_EXPANDED_HEIGHT;
   }
 
   /**


### PR DESCRIPTION
* Collapsed env height is now calculated to fit all envs in collapsed mode with a padding of 7px. All envs are visible without scrolling
* Max collapsed size is 50, to avoid giant envs if only a few are present
* Expanded env height is 170 with a padding of 14px
* Title icon and font sizes depend on collapsed height
* The envs respond to window height resize

5 envs:
![image](https://user-images.githubusercontent.com/35143083/92519282-5bbacc80-f222-11ea-9ed7-cc9848e6caaa.png)

20 envs:
![image](https://user-images.githubusercontent.com/35143083/92519237-49d92980-f222-11ea-9e3a-81bb4ee3e814.png)

40 envs:
![image](https://user-images.githubusercontent.com/35143083/92519342-768d4100-f222-11ea-87e5-4ceafbcd8afd.png)

60 envs (fonts become very small):
![image](https://user-images.githubusercontent.com/35143083/92519365-8442c680-f222-11ea-918f-d3de97dc9c36.png)

20 envs + expanded:
![image](https://user-images.githubusercontent.com/35143083/92519498-b5bb9200-f222-11ea-9884-fc5ce99bce92.png)
