### PR TITLE
Sync time range form and timeline points.

### DIFF
--- a/step-release-vis/src/app/models/TimelinePoint.ts
+++ b/step-release-vis/src/app/models/TimelinePoint.ts
@@ -7,10 +7,8 @@ export class TimelinePoint {
   constructor(timestamp: number, x: number) {
     this.timestamp = timestamp;
     this.x = x;
-    const dateTime = new Date(this.timestamp * 1000)
-      .toLocaleString('en-GB')
-      .split(', ');
-    this.dateString = dateTime[0];
-    this.timeString = dateTime[1];
+    const date = new Date(this.timestamp * 1000);
+    this.dateString = date.toLocaleDateString();
+    this.timeString = date.toLocaleTimeString();
   }
 }


### PR DESCRIPTION
* The time range form at the top always displays the date/time in local format, no way to change that.
* The timeline points were in en-GB format, which made the form and timeline dates be in different formats for certain users, which caused confusion. 
* Now the timeline also displays date/time in local format.